### PR TITLE
use 'timing::timing' instead of 'timing' in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(TIMINGLIBS_DEPENDENCIES
 daq_add_library(TimingController.cpp LINK_LIBRARIES ${TIMINGLIBS_DEPENDENCIES})
 
 ##############################################################################
-daq_add_plugin(TimingHardwareManagerPDI duneDAQModule LINK_LIBRARIES timing timinglibs)
+daq_add_plugin(TimingHardwareManagerPDI duneDAQModule LINK_LIBRARIES timing::timing timinglibs)
 daq_add_plugin(TimingMasterController duneDAQModule LINK_LIBRARIES timinglibs)
 daq_add_plugin(TimingPartitionController duneDAQModule LINK_LIBRARIES timinglibs)
 daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs)


### PR DESCRIPTION
Using `timing` instead of `timing::timing` in CMakeLIsts.txt caused the build to fail if using pre-built `timing` package from cvmfs.

The target name is `timing::timing` in the package mode.