### PR TITLE
the cmake.in is missing a find_package call to timing, this is causin…

### DIFF
--- a/cmake/timinglibsConfig.cmake.in
+++ b/cmake/timinglibsConfig.cmake.in
@@ -4,6 +4,7 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(ers)
+find_dependency(timing)
 find_dependency(Boost COMPONENTS unit_test_framework program_options)
 find_dependency(TRACE)
 


### PR DESCRIPTION
…g build failure if using pre-built timinglibs UPS package (as `timing::timing` is not found, and timinglibs target will be set to NOT_FOUND, example can be found in  repo's recent CI 

https://github.com/DUNE-DAQ/trigger/runs/2513019279?check_suite_focus=true#step:8:420


```
CMake Error at trigger/CMakeLists.txt:15 (find_package):

  Found package configuration file:
    /releases/dunedaq-develop/packages/timinglibs/77e0a5d/slf7.x86_64.e19.prof/timinglibs/lib64/timinglibs/cmake/timinglibsConfig.cmake
  but it set timinglibs_FOUND to FALSE so package "timinglibs" is considered

  to be NOT FOUND.  Reason given by package:
  The following imported targets are referenced, but are missing:
  timing::timing
```


