### PR TITLE
Warn if the TimeSync's system time is far ahead of ours

### DIFF
--- a/include/timinglibs/TimingIssues.hpp
+++ b/include/timinglibs/TimingIssues.hpp
@@ -100,6 +100,8 @@ ERS_DECLARE_ISSUE_BASE(timinglibs,
 
 ERS_DECLARE_ISSUE(timinglibs, InvalidTimeSync, "An invalid TimeSync message was received", ERS_EMPTY)
 
+ERS_DECLARE_ISSUE(timinglibs, EarlyTimeSync, "The most recent TimeSync message is ahead of current system time by " << time_diff << " us.", ((uint64_t)time_diff))
+
 ERS_DECLARE_ISSUE(timinglibs, LateTimeSync, "The most recent TimeSync message is behind current system time by " << time_diff << " us.", ((uint64_t)time_diff))
 
 ERS_DECLARE_ISSUE(timinglibs,


### PR DESCRIPTION
Previously emitted an error when TimeSync's system time is ahead of
ours, even by a little bit, but that can happen when TimeSync sender
is on a different host then the TimestampEstimator. So just warn, and
only when the discrepancy is "large" (currently 10ms)