### PR TITLE
Added the setting of the run number in HSIEvents in FakeHSIEventGenerator and HSIReadout

### DIFF
--- a/plugins/FakeHSIEventGenerator.cpp
+++ b/plugins/FakeHSIEventGenerator.cpp
@@ -235,7 +235,7 @@ FakeHSIEventGenerator::do_hsievent_work(std::atomic<bool>& running_flag)
 
       m_last_generated_timestamp.store(ts);
 
-      dfmessages::HSIEvent event = dfmessages::HSIEvent(m_hsi_device_id, signal_map, ts, m_generated_counter);
+      dfmessages::HSIEvent event = dfmessages::HSIEvent(m_hsi_device_id, signal_map, ts, m_generated_counter, m_run_number);
       send_hsi_event(event);
     } else {
       continue;

--- a/plugins/FakeHSIEventGenerator.hpp
+++ b/plugins/FakeHSIEventGenerator.hpp
@@ -17,6 +17,7 @@
 #include "timinglibs/fakehsieventgeneratorinfo/InfoStructs.hpp"
 
 #include "appfwk/DAQModule.hpp"
+#include "daqdataformats/Types.hpp"
 #include "dfmessages/TimeSync.hpp"
 #include "ers/Issue.hpp"
 #include "iomanager/Receiver.hpp"

--- a/plugins/HSIReadout.hpp
+++ b/plugins/HSIReadout.hpp
@@ -74,6 +74,7 @@ private:
   std::string m_connections_file;
   std::unique_ptr<uhal::ConnectionManager> m_connection_manager;
   std::unique_ptr<uhal::HwInterface> m_hsi_device;
+  std::atomic<daqdataformats::run_number_t> m_run_number;
 
   void do_hsievent_work(std::atomic<bool>&) override;
 


### PR DESCRIPTION
This will allow receiver(s) of HSIEvents to confirm that they are being received in the correct run.

These changes depend on ones in the dfmessages and trigger repos.  The dfmessages ones should be merged first, then these changes, and then the trigger ones.