### PR TITLE
Updated clock frequency defaults to 62.5 MHz

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ A DUNE DAQ module for reading `HSIEvent` from `HSI` hardware. The module periodi
 
 In the absence of real `HSI` hardware, this module can be used to emululate an `HSI`, and act as a source of `HSIEvent`s. The timestamp of the emulated `HSIEvent`s is obtained from timestamp estimates provided by `TimestampEstimator`. The distribution of signals in the `HSIEvent` bitmap along with their rate are configurable via the following parameters.
 
-* `clock_frequency`: Assumed clock frequency in Hz (for current-timestamp estimation); default: `50000000`
+* `clock_frequency`: Assumed clock frequency in Hz (for current-timestamp estimation); default: `62500000`
 
 * `timestamp_offset`: Offset for HSIEvent timestamps in units of clock ticks. Positive offset increases timestamp estimate; default: `0`
 

--- a/python/timinglibs/fake_hsi_app_confgen.py
+++ b/python/timinglibs/fake_hsi_app_confgen.py
@@ -39,7 +39,7 @@ def generate(
         PARTITION = "hsi_readout_test",
         OUTPUT_PATH=".",
         TRIGGER_RATE_HZ: int=1,
-        CLOCK_SPEED_HZ: int = 50000000,
+        CLOCK_SPEED_HZ: int = 62500000,
         HSI_TIMESTAMP_OFFSET: int = 0, # Offset for HSIEvent timestamps in units of clock ticks. Positive offset increases timestamp estimate.
         HSI_DEVICE_ID: int = 0,
         MEAN_SIGNAL_MULTIPLICITY: int = 0,


### PR DESCRIPTION
The full set of repositories that are affected by this change is contained in the following list

```
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dqm.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/flxlibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/timinglibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/triggeralgs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/wibmod.git -b kbiery/62.5MHz_defaults
```

Recall that this first step in the deprecation of legacy hardware is simply switching to a default clock frequency of 62.5 MHz in our scripts, etc.  More changes will come later.