### PR TITLE
Reorganize daqconf schema options

### DIFF
--- a/python/timinglibs/timing_app_confgen.py
+++ b/python/timinglibs/timing_app_confgen.py
@@ -72,14 +72,17 @@ def generate(
     moo.otypes.load_types('timinglibs/timing_app_confgen.jsonnet')
     import dunedaq.timinglibs.timing_app_confgen as timing_app_confgen
     
-    moo.otypes.load_types('daqconf/confgen.jsonnet')
-    import dunedaq.daqconf.confgen as daqconf_confgen
-    
+    moo.otypes.load_types('daqconf/bootgen.jsonnet')
+    import dunedaq.daqconf.bootgen as daqconf_bootgen
+
+    moo.otypes.load_types('daqconf/hsigen.jsonnet')
+    import dunedaq.daqconf.hsigen as daqconf_hsigen
+
     moo.otypes.load_types('timinglibs/confgen.jsonnet')
     import dunedaq.timinglibs.confgen as daqconf_timing_confgen
 
     ## Hack, we shouldn't need to do that, in the future it should be, boot = config_data.boot
-    boot = daqconf_confgen.boot(**config_data.boot)
+    boot = daqconf_bootgen.boot(**config_data.boot)
     if DEBUG: console.log(f"boot configuration object: {boot.pod()}")
 
     ## etc...
@@ -92,7 +95,7 @@ def generate(
     tfc_conf_gen = daqconf_timing_confgen.timing_fanout_controller(**config_data.timing_fanout_controller)
     if DEBUG: console.log(f"timing_fanout_controller configuration object: {tfc_conf_gen.pod()}")
 
-    hsi_conf_gen = daqconf_confgen.hsi(**config_data.hsi)
+    hsi_conf_gen = daqconf_hsigen.hsi(**config_data.hsi)
     if DEBUG: console.log(f"hsi configuration object: {hsi_conf_gen.pod()}")
 
     tec_conf_gen = timing_app_confgen.timing_endpoint_controller(**config_data.timing_endpoint_controller)
@@ -376,7 +379,7 @@ def generate(
     from daqconf.core.conf_utils import make_app_command_data
     # Arrange per-app command data into the format used by util.write_json_files()
     app_command_datas = {
-        name : make_app_command_data(the_system, app, name, verbose=DEBUG, use_k8s=boot.use_k8s, use_connectivity_service=boot.use_connectivity_service)
+        name : make_app_command_data(the_system, app, name, verbose=DEBUG, use_k8s=(boot.process_manager=='k8s'), use_connectivity_service=boot.use_connectivity_service)
         for name,app in the_system.apps.items()
     }
 

--- a/schema/timinglibs/confgen.jsonnet
+++ b/schema/timinglibs/confgen.jsonnet
@@ -1,8 +1,10 @@
 // This is the configuration schema for timinglibs
 
 local moo = import "moo.jsonnet";
-local sdc = import "daqconf/confgen.jsonnet";
-local daqconf = moo.oschema.hier(sdc).dunedaq.daqconf.confgen;
+
+local sboot = import "daqconf/bootgen.jsonnet";
+local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
+
 local stime = import "timinglibs/timingcmd.jsonnet";
 local timingcmd = moo.oschema.hier(stime).dunedaq.timinglibs.timingcmd;
 
@@ -18,30 +20,30 @@ local cs = {
     s.field('firmware_type',              self.firmware_type, default='pdii',       doc="Timing firmware type, pdi (NRZ) or pdii (no cdr)"),
     s.field('gather_interval',            self.number,        default=5e5,         doc='Gather interval for hardware polling [us]'),
     s.field('gather_interval_debug',      self.number,        default=10e7,        doc='Gather interval for hardware polling debug/i2c [us]'),
-    s.field('host_thi',                   daqconf.Host,       default='localhost', doc='Host to run the (global) timing hardware interface app on'),
-    s.field('timing_hw_connections_file', daqconf.Path,       default="${TIMING_SHARE}/config/etc/connections.xml", doc='Path to timing hardware connections file'),
-    s.field('hsi_device_name',            daqconf.Str,        default="",  doc='Real HSI hardware only: device name of HSI hw'),
+    s.field('host_thi',                   bootgen.Host,       default='localhost', doc='Host to run the (global) timing hardware interface app on'),
+    s.field('timing_hw_connections_file', bootgen.Path,       default="${TIMING_SHARE}/config/etc/connections.xml", doc='Path to timing hardware connections file'),
+    s.field('hsi_device_name',            bootgen.Str,        default="",  doc='Real HSI hardware only: device name of HSI hw'),
   ]),
 
   timing_master_controller: s.record("timing_master_controller", [
-    s.field('host_tmc',                       daqconf.Host, default='localhost', doc='Host to run the (global) timing master controller app on'),
-    s.field("enable_hardware_state_recovery", daqconf.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
-    s.field('master_device_name',             daqconf.Str,  default="",          doc='Device name of timing master hw'),
+    s.field('host_tmc',                       bootgen.Host, default='localhost', doc='Host to run the (global) timing master controller app on'),
+    s.field("enable_hardware_state_recovery", bootgen.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
+    s.field('master_device_name',             bootgen.Str,  default="",          doc='Device name of timing master hw'),
     s.field('master_endpoint_scan_period',    self.number,  default=0,           doc="Master controller continuously scans the endpoint addresses provided. This controls period of scan [ms]. 0 for disable."),
-    s.field('master_clock_file',              daqconf.Path, default="",          doc='Path to custom PLL config file for master device'),
+    s.field('master_clock_file',              bootgen.Path, default="",          doc='Path to custom PLL config file for master device'),
     s.field('master_clock_mode',              self.number,  default=-1,          doc='Fanout mode for master device.'),
     s.field('monitored_endpoints',            timingcmd.TimingEndpointLocations, default=[], doc='List of endpoints to be monitored.'),
   ]),
 
   timing_fanout_controller: s.record("timing_fanout_controller", [
-    s.field("enable_hardware_state_recovery", daqconf.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
-    s.field('fanout_device_name',             daqconf.Str,  default="",          doc='Device name of timing fanout hw'),
-    s.field('host_tfc',                       daqconf.Host, default='localhost', doc='Host to run the (global) timing master controller app on'),
-    s.field('fanout_clock_file',              daqconf.Path, default="",          doc='Path to custom PLL config file for fanout device'),
+    s.field("enable_hardware_state_recovery", bootgen.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
+    s.field('fanout_device_name',             bootgen.Str,  default="",          doc='Device name of timing fanout hw'),
+    s.field('host_tfc',                       bootgen.Host, default='localhost', doc='Host to run the (global) timing master controller app on'),
+    s.field('fanout_clock_file',              bootgen.Path, default="",          doc='Path to custom PLL config file for fanout device'),
   ]),
 
   timing_gen: s.record('timing_gen', [
-    s.field('boot',                      daqconf.boot,                   default=daqconf.boot,                   doc='Boot parameters'),
+    s.field('boot',                      bootgen.boot,                   default=bootgen.boot,                   doc='Boot parameters'),
     s.field('timing_hardware_interface', self.timing_hardware_interface, default=self.timing_hardware_interface, doc='THI parameters'),
     s.field('timing_master_controller',  self.timing_master_controller,  default=self.timing_master_controller,  doc='TMC parameters'),
     s.field('timing_fanout_controller',  self.timing_fanout_controller,  default=self.timing_fanout_controller,  doc='TFC parameters'),
@@ -50,4 +52,4 @@ local cs = {
 };
 
 // Output a topologically sorted array.
-sdc + stime + moo.oschema.sort_select(cs, ns)
+sboot + stime + moo.oschema.sort_select(cs, ns)

--- a/schema/timinglibs/confgen.jsonnet
+++ b/schema/timinglibs/confgen.jsonnet
@@ -2,6 +2,11 @@
 
 local moo = import "moo.jsonnet";
 
+# daqconf basic/standard types
+local stypes = import "daqconf/types.jsonnet";
+local types = moo.oschema.hier(stypes).dunedaq.daqconf.types;
+
+# daqconf boot record
 local sboot = import "daqconf/bootgen.jsonnet";
 local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
 
@@ -20,26 +25,26 @@ local cs = {
     s.field('firmware_type',              self.firmware_type, default='pdii',       doc="Timing firmware type, pdi (NRZ) or pdii (no cdr)"),
     s.field('gather_interval',            self.number,        default=5e5,         doc='Gather interval for hardware polling [us]'),
     s.field('gather_interval_debug',      self.number,        default=10e7,        doc='Gather interval for hardware polling debug/i2c [us]'),
-    s.field('host_thi',                   bootgen.Host,       default='localhost', doc='Host to run the (global) timing hardware interface app on'),
-    s.field('timing_hw_connections_file', bootgen.Path,       default="${TIMING_SHARE}/config/etc/connections.xml", doc='Path to timing hardware connections file'),
-    s.field('hsi_device_name',            bootgen.Str,        default="",  doc='Real HSI hardware only: device name of HSI hw'),
+    s.field('host_thi',                   types.host,       default='localhost', doc='Host to run the (global) timing hardware interface app on'),
+    s.field('timing_hw_connections_file', types.path,       default="${TIMING_SHARE}/config/etc/connections.xml", doc='Path to timing hardware connections file'),
+    s.field('hsi_device_name',            types.string,        default="",  doc='Real HSI hardware only: device name of HSI hw'),
   ]),
 
   timing_master_controller: s.record("timing_master_controller", [
-    s.field('host_tmc',                       bootgen.Host, default='localhost', doc='Host to run the (global) timing master controller app on'),
-    s.field("enable_hardware_state_recovery", bootgen.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
-    s.field('master_device_name',             bootgen.Str,  default="",          doc='Device name of timing master hw'),
+    s.field('host_tmc',                       types.host, default='localhost', doc='Host to run the (global) timing master controller app on'),
+    s.field("enable_hardware_state_recovery", types.flag, default=true,        doc="Enable (or not) hardware state recovery"),
+    s.field('master_device_name',             types.string,  default="",          doc='Device name of timing master hw'),
     s.field('master_endpoint_scan_period',    self.number,  default=0,           doc="Master controller continuously scans the endpoint addresses provided. This controls period of scan [ms]. 0 for disable."),
-    s.field('master_clock_file',              bootgen.Path, default="",          doc='Path to custom PLL config file for master device'),
+    s.field('master_clock_file',              types.path, default="",          doc='Path to custom PLL config file for master device'),
     s.field('master_clock_mode',              self.number,  default=-1,          doc='Fanout mode for master device.'),
     s.field('monitored_endpoints',            timingcmd.TimingEndpointLocations, default=[], doc='List of endpoints to be monitored.'),
   ]),
 
   timing_fanout_controller: s.record("timing_fanout_controller", [
-    s.field("enable_hardware_state_recovery", bootgen.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
-    s.field('fanout_device_name',             bootgen.Str,  default="",          doc='Device name of timing fanout hw'),
-    s.field('host_tfc',                       bootgen.Host, default='localhost', doc='Host to run the (global) timing master controller app on'),
-    s.field('fanout_clock_file',              bootgen.Path, default="",          doc='Path to custom PLL config file for fanout device'),
+    s.field("enable_hardware_state_recovery", types.flag, default=true,        doc="Enable (or not) hardware state recovery"),
+    s.field('fanout_device_name',             types.string,  default="",          doc='Device name of timing fanout hw'),
+    s.field('host_tfc',                       types.host, default='localhost', doc='Host to run the (global) timing master controller app on'),
+    s.field('fanout_clock_file',              types.path, default="",          doc='Path to custom PLL config file for fanout device'),
   ]),
 
   timing_gen: s.record('timing_gen', [

--- a/schema/timinglibs/timing_app_confgen.jsonnet
+++ b/schema/timinglibs/timing_app_confgen.jsonnet
@@ -1,8 +1,16 @@
 // This is the standalone configuration schema for timinglibs
 
 local moo = import "moo.jsonnet";
-local sdc = import "daqconf/confgen.jsonnet";
-local daqconf = moo.oschema.hier(sdc).dunedaq.daqconf.confgen;
+
+local stypes = import "daqconf/types.jsonnet";
+local types = moo.oschema.hier(stypes).dunedaq.daqconf.types;
+
+local sbootgen = import "daqconf/bootgen.jsonnet";
+local bootgen = moo.oschema.hier(sbootgen).dunedaq.daqconf.bootgen;
+
+local shsigen = import "daqconf/hsigen.jsonnet";
+local hsigen = moo.oschema.hier(shsigen).dunedaq.daqconf.hsigen;
+
 local stime = import "timinglibs/timingcmd.jsonnet";
 local timingcmd = moo.oschema.hier(stime).dunedaq.timinglibs.timingcmd;
 local stiminglibs_confgen = import "timinglibs/confgen.jsonnet";
@@ -15,23 +23,24 @@ local s = moo.oschema.schema(ns);
 local cs = {
 
    timing_endpoint_controller: s.record("timing_endpoint_controller", [
-    s.field('host_tec',                       daqconf.Host, default='localhost', doc='Host to run the controller app on'),
-    s.field("enable_hardware_state_recovery", daqconf.Flag, default=true,        doc="Enable (or not) hardware state recovery"),
-    s.field('endpoint_device_name',           daqconf.Str,  default="",          doc='Device name of timing hw'),
-    s.field('endpoint_clock_file',            daqconf.Path, default="",          doc='Path to custom PLL config file for device'),
+    s.field('host_tec',                       types.host, default='localhost', doc='Host to run the controller app on'),
+    s.field("enable_hardware_state_recovery", types.flag, default=true,        doc="Enable (or not) hardware state recovery"),
+    s.field('endpoint_device_name',           types.string,  default="",          doc='Device name of timing hw'),
+    s.field('endpoint_clock_file',            types.path, default="",          doc='Path to custom PLL config file for device'),
     s.field('endpoint_address',               timinglibs_confgen.number, default=0,           doc='Endpoint address.'),
     s.field('endpoint_partition',             timinglibs_confgen.number, default=0,           doc='Endpoint partitiion.'),
   ]),
 
   timing_gen: s.record('app_confgen', [
-    s.field('boot',                       daqconf.boot,                                  default=daqconf.boot,                                  doc='Boot parameters'),
+    s.field('boot',                       bootgen.boot,                                  default=bootgen.boot,                                  doc='Boot parameters'),
     s.field('timing_hardware_interface',  timinglibs_confgen.timing_hardware_interface,  default=timinglibs_confgen.timing_hardware_interface,  doc='THI parameters'),
     s.field('timing_master_controller',   timinglibs_confgen.timing_master_controller,   default=timinglibs_confgen.timing_master_controller,   doc='TMC parameters'),
     s.field('timing_fanout_controller',   timinglibs_confgen.timing_fanout_controller,   default=timinglibs_confgen.timing_fanout_controller,   doc='TFC parameters'),
-    s.field('hsi',                        daqconf.hsi,                                   default=daqconf.hsi,                                   doc='HSI parameters'),
+    s.field('hsi',                        hsigen.hsi,                                    default=hsigen.hsi,                                    doc='HSI parameters'),
     s.field('timing_endpoint_controller', self.timing_endpoint_controller,               default=self.timing_endpoint_controller,               doc='TEC parameters')
   ])
 };
 
 // Output a topologically sorted array.
-sdc + stime + stiminglibs_confgen + moo.oschema.sort_select(cs, ns)
+stypes + sbootgen + shsigen + stime + stiminglibs_confgen + moo.oschema.sort_select(cs, ns)
+// 

--- a/scripts/daqconf_timing_gen
+++ b/scripts/daqconf_timing_gen
@@ -40,11 +40,11 @@ def cli(config, debug, json_dir):
     # Loading this one another time... (first time in config_file.generate_cli_from_schema)
     moo.otypes.load_types('timinglibs/confgen.jsonnet')
     import dunedaq.timinglibs.confgen as confgen
-    moo.otypes.load_types('daqconf/confgen.jsonnet')
-    import dunedaq.daqconf.confgen as daqconf
+    moo.otypes.load_types('daqconf/bootgen.jsonnet')
+    import dunedaq.daqconf.bootgen as bootgen
 
     ## Hack, we shouldn't need to do that, in the future it should be, boot = config_data.boot
-    boot = daqconf.boot(**config_data.boot)
+    boot = bootgen.boot(**config_data.boot)
     if debug: console.log(f"boot configuration object: {boot.pod()}")
 
     ## etc...
@@ -57,7 +57,7 @@ def cli(config, debug, json_dir):
     tfc = confgen.timing_fanout_controller(**config_data.timing_fanout_controller)
     if debug: console.log(f"timing_fanout_controller configuration object: {tfc.pod()}")
 
-    if boot.use_k8s and not boot.image:
+    if boot.process_manager == 'k8s' and not boot.k8s_image:
         raise Exception("You need to provide an --image if running with k8s")
 
     console.log("Loading timing hardware config generator")
@@ -118,7 +118,7 @@ def cli(config, debug, json_dir):
     from daqconf.core.conf_utils import make_app_command_data
     # Arrange per-app command data into the format used by util.write_json_files()
     app_command_datas = {
-        name : make_app_command_data(the_system, app, name, verbose=debug, use_k8s=boot.use_k8s, use_connectivity_service=boot.use_connectivity_service)
+        name : make_app_command_data(the_system, app, name, verbose=debug, use_k8s=(boot.process_manager=='k8s'), use_connectivity_service=boot.use_connectivity_service)
         for name,app in the_system.apps.items()
     }
 


### PR DESCRIPTION
Implement the code confgen parameters reorganisation described in https://github.com/DUNE-DAQ/daqconf/pull/330 and https://github.com/DUNE-DAQ/daqconf/pull/354