### PR TITLE
Adding timing database 

### DIFF
--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -221,7 +221,7 @@
     <attr name="endpoint_scan_period" type="u32" val="1000"/>
     <attr name="clock_config" type="string" val="https://github.com/DUNE-DAQ/timing/blob/develop/config/etc/clock/nocdr/Si5395-RevA-069a_ep-Registers.txt"/>
     <attr name="soft" type="bool" val="0"/>
-    <attr name="fanout_mode" type="string" val="-1"/>
+    <attr name="fanout_mode" type="s32" val="-1"/>
     <rel name="monitored_endpoints">
      <ref class="EndpointLocation" id="dummy_endpoint1"/>
      <ref class="EndpointLocation" id="dummy_endpoint2"/>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -66,16 +66,24 @@
 <info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="jr19588" created-on="kipper.phy.bris.ac.uk" creation-time="20240417T160310" last-modified-by="jr19588" last-modified-on="kipper.phy.bris.ac.uk" last-modification-time="20240417T160310"/>
 
 <include>
- <file path="schema/timinglibs/timing.schema.xml"/>
- <file path="schema/confmodel/dunedaq.schema.xml"/>
+    <file path="schema/confmodel/dunedaq.schema.xml"/>
+    <file path="schema/timinglibs/timing.schema.xml"/>
 </include>
 
 <obj class="DaqApplication" id="tmc">
     <attr name="application_name" type="string" val="daq_application"/>
+    <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+    <rel name="modules">
+     <ref class="TimingMasterControllerPDI" id="tmc"/>
+    </rel>
 </obj>
 
 <obj class="DaqApplication" id="thi">
     <attr name="application_name" type="string" val="daq_application"/>
+    <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
+    <rel name="modules">
+     <ref class="TimingHardwareManagerPDII" id="thi"/>
+    </rel>
 </obj>
 
 <obj class="Session" id="test-session">
@@ -90,6 +98,17 @@
     <rel name="segment" class="Segment" id="generated-segment"/>  
 </obj>
 
+<obj class="RCApplication" id="my-controller">
+    <attr name="commandline_parameters" type="string">
+     <data val="file:////home/jr19588/NFD_DEV_240701_C8/sourcecode/timinglibs/controller.json ${PORT} my-controller test-session"/>
+    </attr>
+    <attr name="application_name" type="string" val="drunc-controller"/>
+    <rel name="runs_on" class="VirtualHost" id="controller"/>
+    <rel name="exposes_service">
+        <ref class="Service" id="root-controller_control"/>
+    </rel>
+    <rel name="fsm" class="FSMconfiguration" id="fsmConf-test"/>
+</obj>
 
 <obj class="Segment" id="generated-segment">
     <rel name="applications">
@@ -101,10 +120,8 @@
 
 
 <obj class="ConnectionService" id="connectionservice">
-    <attr name="enabled" type="bool" val="1"/>
     <attr name="application_name" type="string" val="gunicorn"/>
     <attr name="commandline_parameters" type="string" val="--bind=0.0.0.0:15000 --workers=1 --worker-class=gthread --threads=2 --timeout=0 --pid=connectionservice_15000.pid connection-service.connection-flask:app"/>
-    <attr name="port" type="u16" val="15000"/>
     <attr name="threads" type="u16" val="1"/>
     <rel name="applicationEnvironment">
      <ref class="VariableSet" id="consvc_ssh"/>
@@ -135,7 +152,7 @@
 </obj>
 
 <obj class="TimingController" id="TimingController1">
- <attr name="device_str" type="string" val="TEST_CTL"/>
+ <attr name="device" type="string" val="TEST_CTL"/>
  <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>
  <attr name="timing_session_name" type="string" val="test"/>
 </obj>
@@ -151,9 +168,7 @@
     <attr name="clock_config" type="string" val="https://github.com/DUNE-DAQ/timing/blob/develop/config/etc/clock/nocdr/Si5395-RevA-069a_ep-Registers.txt"/>
     <attr name="soft" type="bool" val="0"/>
     <attr name="fanout_mode" type="string" val="-1"/>
-    <attr name="fanout_slot" type="u32" val="0"/>
-    <attr name="sfp_slot" type="u32" val="0"/>
-    <attr name="address" type="u32" val="0"/>
+    <rel name="monitoredEndpointsSet" class="EndpointLocationSet" id="ept-list"></rel>
 </obj>
    
 <obj class="TimingHardwareManagerPDII" id="thi">

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -190,22 +190,43 @@
  <rel name="runs_on" class="PhysicalHost" id="localhost"/>
 </obj>
 
-<obj class="EndpointLocation" id="dummy_endpoint">
-    <attr name="fanout_slot" type="u32" val="0"/>
-    <attr name="sfp_slot" type="u32" val="0"/>
-    <attr name="address" type="u32" val="0"/>
-</obj>
+ <obj class="EndpointLocation" id="dummy_endpoint1">
+    <attr name="fanout_slot" type="s32" val="-1"/>
+    <attr name="sfp_slot" type="s32" val="-1"/>
+    <attr name="address" type="u32" val="1"/>
+ </obj>
+
+ <obj class="EndpointLocation" id="dummy_endpoint2">
+    <attr name="fanout_slot" type="s32" val="-1"/>
+    <attr name="sfp_slot" type="s32" val="-1"/>
+    <attr name="address" type="u32" val="2"/>
+ </obj>
+
+ <obj class="EndpointLocation" id="dummy_endpoint3">
+    <attr name="fanout_slot" type="s32" val="-1"/>
+    <attr name="sfp_slot" type="s32" val="-1"/>
+    <attr name="address" type="u32" val="3"/>
+ </obj>
+
+ <obj class="EndpointLocation" id="dummy_endpoint4">
+    <attr name="fanout_slot" type="s32" val="-1"/>
+    <attr name="sfp_slot" type="s32" val="-1"/>
+    <attr name="address" type="u32" val="4"/>
+ </obj>
 
 <obj class="TimingMasterControllerPDII" id="tmc">
     <attr name="device" type="string" val="MST_FMC"/>
     <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>
     <attr name="timing_session_name" type="string" val=""/>
-    <attr name="endpoint_scan_period" type="u32" val="0"/>
+    <attr name="endpoint_scan_period" type="u32" val="1000"/>
     <attr name="clock_config" type="string" val="https://github.com/DUNE-DAQ/timing/blob/develop/config/etc/clock/nocdr/Si5395-RevA-069a_ep-Registers.txt"/>
     <attr name="soft" type="bool" val="0"/>
     <attr name="fanout_mode" type="string" val="-1"/>
     <rel name="monitored_endpoints">
-     <ref class="EndpointLocation" id="dummy_endpoint"/>
+     <ref class="EndpointLocation" id="dummy_endpoint1"/>
+     <ref class="EndpointLocation" id="dummy_endpoint2"/>
+     <ref class="EndpointLocation" id="dummy_endpoint3"/>
+     <ref class="EndpointLocation" id="dummy_endpoint4"/>
     </rel>
     <rel name="outputs">
      <ref class="NetworkConnection" id="timing_cmds"/>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -151,6 +151,19 @@
     </rel>
 </obj>
 
+<obj class="PhysicalHost" id="localhost">
+ <rel name="contains">
+  <ref class="ProcessingResource" id="cpus"/>
+ </rel>
+</obj>
+
+<obj class="VirtualHost" id="vlocalhost">
+ <rel name="uses">
+  <ref class="ProcessingResource" id="cpus"/>
+ </rel>
+ <rel name="runs_on" class="PhysicalHost" id="localhost"/>
+</obj>
+
 <obj class="TimingController" id="TimingController1">
  <attr name="device" type="string" val="TEST_CTL"/>
  <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -119,6 +119,32 @@
 </obj>
 
 
+<obj class="Service" id="timing_commands">
+ <attr name="protocol" type="string" val="tcp"/>
+ <attr name="port" type="u16" val="0"/>
+</obj>
+
+<obj class="NetworkConnection" id="timing_cmds">
+ <attr name="data_type" type="string" val="TimingHwCmd"/>
+ <attr name="send_timeout_ms" type="u32" val="100"/>
+ <attr name="recv_timeout_ms" type="u32" val="100"/>
+ <attr name="connection_type" type="enum" val="kSendRecv"/>
+ <rel name="associated_service" class="Service" id="timing_commands"/>
+</obj>
+
+<obj class="Service" id="device_op_mon">
+ <attr name="protocol" type="string" val="tcp"/>
+ <attr name="port" type="u16" val="0"/>
+</obj>
+
+<obj class="NetworkConnection" id="MST_FMC_info">
+ <attr name="data_type" type="string" val="JSON"/>
+ <attr name="send_timeout_ms" type="u32" val="100"/>
+ <attr name="recv_timeout_ms" type="u32" val="100"/>
+ <attr name="connection_type" type="enum" val="kPubSub"/>
+ <rel name="associated_service" class="Service" id="device_op_mon"/>
+</obj>
+
 <obj class="ConnectionService" id="connectionservice">
     <attr name="application_name" type="string" val="gunicorn"/>
     <attr name="commandline_parameters" type="string" val="--bind=0.0.0.0:15000 --workers=1 --worker-class=gthread --threads=2 --timeout=0 --pid=connectionservice_15000.pid connection-service.connection-flask:app"/>
@@ -181,12 +207,24 @@
     <rel name="monitored_endpoints">
      <ref class="EndpointLocation" id="dummy_endpoint"/>
     </rel>
+    <rel name="outputs">
+     <ref class="NetworkConnection" id="timing_cmds"/>
+    </rel>
+    <rel name="inputs">
+     <ref class="NetworkConnection" id="MST_FMC_info"/>
+    </rel>
 </obj>
 
 <obj class="TimingHardwareManagerPDII" id="thi">
  <attr name="uhal_log_level" type="enum" val="notice"/>
- <attr name="connections_file" type="string" val="$TIMING_SHARE/config/etc/connections.xml"/>
+ <attr name="connections_file" type="string" val="connections.xml"/>
  <attr name="monitored_device_name_master" type="string" val="MST_FMC"/>
+ <rel name="inputs">
+  <ref class="NetworkConnection" id="timing_cmds"/>
+ </rel>
+ <rel name="outputs">
+  <ref class="NetworkConnection" id="MST_FMC_info"/>
+ </rel>
 </obj>
 
 </oks-data>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -146,7 +146,7 @@
     <attr name="address" type="u32" val="0"/>
 </obj>
 
-<obj class="TimingMasterController" id="tmc">
+<obj class="TimingMasterControllerPDI" id="tmc">
     <attr name="endpoint_scan_period" type="u32" val="0"/>
     <attr name="clock_config" type="string" val="https://github.com/DUNE-DAQ/timing/blob/develop/config/etc/clock/nocdr/Si5395-RevA-069a_ep-Registers.txt"/>
     <attr name="soft" type="bool" val="0"/>
@@ -156,7 +156,7 @@
     <attr name="address" type="u32" val="0"/>
 </obj>
    
-<obj class="TimingHardwareInterface" id="thi">
+<obj class="TimingHardwareManagerPDII" id="thi">
  <attr name="uhal_log_level" type="enum" val="notice"/>
  <attr name="connections_file" type="string" val="/home/jr19588/NFD_DEV_240507_C8/.test_connections.xml"/>
 </obj>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -74,7 +74,7 @@
     <attr name="application_name" type="string" val="daq_application"/>
     <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
     <rel name="modules">
-     <ref class="TimingMasterControllerPDI" id="tmc"/>
+     <ref class="TimingMasterControllerPDII" id="tmc"/>
     </rel>
 </obj>
 
@@ -164,29 +164,29 @@
  <rel name="runs_on" class="PhysicalHost" id="localhost"/>
 </obj>
 
-<obj class="TimingController" id="TimingController1">
- <attr name="device" type="string" val="TEST_CTL"/>
- <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>
- <attr name="timing_session_name" type="string" val="test"/>
-</obj>
-
-<obj class="EndpointLocation" id="monitored_endpoints">
+<obj class="EndpointLocation" id="dummy_endpoint">
     <attr name="fanout_slot" type="u32" val="0"/>
     <attr name="sfp_slot" type="u32" val="0"/>
     <attr name="address" type="u32" val="0"/>
 </obj>
 
-<obj class="TimingMasterControllerPDI" id="tmc">
+<obj class="TimingMasterControllerPDII" id="tmc">
+    <attr name="device" type="string" val="MST_FMC"/>
+    <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>
+    <attr name="timing_session_name" type="string" val=""/>
     <attr name="endpoint_scan_period" type="u32" val="0"/>
     <attr name="clock_config" type="string" val="https://github.com/DUNE-DAQ/timing/blob/develop/config/etc/clock/nocdr/Si5395-RevA-069a_ep-Registers.txt"/>
     <attr name="soft" type="bool" val="0"/>
     <attr name="fanout_mode" type="string" val="-1"/>
-    <rel name="monitoredEndpointsSet" class="EndpointLocationSet" id="ept-list"></rel>
+    <rel name="monitored_endpoints">
+     <ref class="EndpointLocation" id="dummy_endpoint"/>
+    </rel>
 </obj>
-   
+
 <obj class="TimingHardwareManagerPDII" id="thi">
  <attr name="uhal_log_level" type="enum" val="notice"/>
- <attr name="connections_file" type="string" val="/home/jr19588/NFD_DEV_240507_C8/.test_connections.xml"/>
+ <attr name="connections_file" type="string" val="$TIMING_SHARE/config/etc/connections.xml"/>
+ <attr name="monitored_device_name_master" type="string" val="MST_FMC"/>
 </obj>
 
 </oks-data>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="ASCII"?>
+
+<!-- oks-data version 2.2 -->
+
+
+<!DOCTYPE oks-data [
+  <!ELEMENT oks-data (info, (include)?, (comments)?, (obj)+)>
+  <!ELEMENT info EMPTY>
+  <!ATTLIST info
+      name CDATA #IMPLIED
+      type CDATA #IMPLIED
+      num-of-items CDATA #REQUIRED
+      oks-format CDATA #FIXED "data"
+      oks-version CDATA #REQUIRED
+      created-by CDATA #IMPLIED
+      created-on CDATA #IMPLIED
+      creation-time CDATA #IMPLIED
+      last-modified-by CDATA #IMPLIED
+      last-modified-on CDATA #IMPLIED
+      last-modification-time CDATA #IMPLIED
+  >
+  <!ELEMENT include (file)*>
+  <!ELEMENT file EMPTY>
+  <!ATTLIST file
+      path CDATA #REQUIRED
+  >
+  <!ELEMENT comments (comment)*>
+  <!ELEMENT comment EMPTY>
+  <!ATTLIST comment
+      creation-time CDATA #REQUIRED
+      created-by CDATA #REQUIRED
+      created-on CDATA #REQUIRED
+      author CDATA #REQUIRED
+      text CDATA #REQUIRED
+  >
+  <!ELEMENT obj (attr | rel)*>
+  <!ATTLIST obj
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+  <!ELEMENT attr (data)*>
+  <!ATTLIST attr
+      name CDATA #REQUIRED
+      type (bool|s8|u8|s16|u16|s32|u32|s64|u64|float|double|date|time|string|uid|enum|class|-) "-"
+      val CDATA ""
+  >
+  <!ELEMENT data EMPTY>
+  <!ATTLIST data
+      val CDATA #REQUIRED
+  >
+  <!ELEMENT rel (ref)*>
+  <!ATTLIST rel
+      name CDATA #REQUIRED
+      class CDATA ""
+      id CDATA ""
+  >
+  <!ELEMENT ref EMPTY>
+  <!ATTLIST ref
+      class CDATA #REQUIRED
+      id CDATA #REQUIRED
+  >
+]>
+
+<oks-data>
+
+<info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="jr19588" created-on="kipper.phy.bris.ac.uk" creation-time="20240417T160310" last-modified-by="jr19588" last-modified-on="kipper.phy.bris.ac.uk" last-modification-time="20240417T160310"/>
+
+<include>
+ <file path="/home/jr19588/NFD_DEV_240507_C8/sourcecode/timinglibs/schema/timinglibs/timing.schema.xml"/>
+ <file path="schema/coredal/dunedaq.schema.xml"/>
+</include>
+
+<obj class="DaqApplication" id="tmc">
+    <attr name="application_name" type="string" val="daq_application"/>
+</obj>
+
+<obj class="DaqApplication" id="thi">
+    <attr name="application_name" type="string" val="daq_application"/>
+</obj>
+
+<obj class="Session" id="test-session">
+    <attr name="use_connectivity_server" type="bool" val="1"/>
+    <attr name="connectivity_service_interval_ms" type="u32" val="2000"/>
+    <attr name="data_request_timeout_ms" type="u32" val="1000"/>
+    <attr name="data_rate_slowdown_factor" type="u32" val="1"/>
+    <attr name="rte_script" type="string" val="/home/jr19588/NFD_DEV_240507_C8/install/daq_app_rte.sh"/>
+    <rel name="environment">
+     <ref class="VariableSet" id="common-env"/>
+    </rel>
+    <rel name="segment" class="Segment" id="generated-segment"/>  
+</obj>
+
+
+<obj class="Segment" id="generated-segment">
+    <rel name="applications">
+     <ref class="DaqApplication" id="tmc"/>
+     <ref class="DaqApplication" id="thi"/>
+    </rel>
+    <rel name="controller" class="RCApplication" id="my-controller"/>
+</obj>
+
+
+<obj class="ConnectionService" id="connectionservice">
+    <attr name="enabled" type="bool" val="1"/>
+    <attr name="application_name" type="string" val="gunicorn"/>
+    <attr name="commandline_parameters" type="string" val="--bind=0.0.0.0:15000 --workers=1 --worker-class=gthread --threads=2 --timeout=0 --pid=connectionservice_15000.pid connection-service.connection-flask:app"/>
+    <attr name="port" type="u16" val="15000"/>
+    <attr name="threads" type="u16" val="1"/>
+    <rel name="applicationEnvironment">
+     <ref class="VariableSet" id="consvc_ssh"/>
+    </rel>
+    <rel name="runs_on" class="VirtualHost" id="connectionservice"/>
+</obj>
+
+   <obj class="VariableSet" id="common-env">
+    <rel name="contains">
+     <ref class="Variable" id="DUNEDAQ_ERS_ERROR"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_FATAL"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_INFO"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_VERBOSITY_LEVEL"/>
+     <ref class="Variable" id="DUNEDAQ_ERS_WARNING"/>
+     <ref class="Variable" id="DUNEDAQ_PARTITION"/>
+    </rel>
+   </obj>
+
+<obj class="VariableSet" id="daq_application_ssh">
+    <rel name="contains">
+     <ref class="Variable" id="CMD_FAC"/>
+     <ref class="Variable" id="CONNECTION_SERVER"/>
+     <ref class="Variable" id="DETCHANNELMAPS_SHARE"/>
+     <ref class="Variable" id="INFO_SVC"/>
+     <ref class="Variable" id="TIMING_SHARE"/>
+     <ref class="Variable" id="TRACE_FILE"/>
+    </rel>
+</obj>
+
+<obj class="TimingController" id="TimingController1">
+ <attr name="device_str" type="string" val="TEST_CTL"/>
+ <attr name="hardware_state_recovery_enabled" type="bool" val="1"/>
+ <attr name="timing_session_name" type="string" val="test"/>
+</obj>
+
+<obj class="EndpointLocation" id="monitored_endpoints">
+    <attr name="fanout_slot" type="u32" val="0"/>
+    <attr name="sfp_slot" type="u32" val="0"/>
+    <attr name="address" type="u32" val="0"/>
+</obj>
+
+<obj class="TimingMasterController" id="tmc">
+    <attr name="endpoint_scan_period" type="u32" val="0"/>
+    <attr name="clock_config" type="string" val="https://github.com/DUNE-DAQ/timing/blob/develop/config/etc/clock/nocdr/Si5395-RevA-069a_ep-Registers.txt"/>
+    <attr name="soft" type="bool" val="0"/>
+    <attr name="fanout_mode" type="string" val="-1"/>
+    <attr name="fanout_slot" type="u32" val="0"/>
+    <attr name="sfp_slot" type="u32" val="0"/>
+    <attr name="address" type="u32" val="0"/>
+</obj>
+   
+<obj class="TimingHardwareInterface" id="thi">
+ <attr name="uhal_log_level" type="enum" val="notice"/>
+ <attr name="connections_file" type="string" val="/home/jr19588/NFD_DEV_240507_C8/.test_connections.xml"/>
+</obj>
+
+</oks-data>

--- a/config/timing.data.xml
+++ b/config/timing.data.xml
@@ -66,8 +66,8 @@
 <info name="" type="" num-of-items="2" oks-format="data" oks-version="862f2957270" created-by="jr19588" created-on="kipper.phy.bris.ac.uk" creation-time="20240417T160310" last-modified-by="jr19588" last-modified-on="kipper.phy.bris.ac.uk" last-modification-time="20240417T160310"/>
 
 <include>
- <file path="/home/jr19588/NFD_DEV_240507_C8/sourcecode/timinglibs/schema/timinglibs/timing.schema.xml"/>
- <file path="schema/coredal/dunedaq.schema.xml"/>
+ <file path="schema/timinglibs/timing.schema.xml"/>
+ <file path="schema/confmodel/dunedaq.schema.xml"/>
 </include>
 
 <obj class="DaqApplication" id="tmc">

--- a/plugins/TimingEndpointController.cpp
+++ b/plugins/TimingEndpointController.cpp
@@ -55,12 +55,10 @@ TimingEndpointController::do_configure(const nlohmann::json& data)
 {  
   auto mdal = m_params->cast<dal::TimingEndpointController>(); 
 
-  if (mdal->get_device_str().empty()) {
+  if (mdal->get_device().empty()) {
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
-  m_timing_device = mdal->get_device_str();
-  m_hardware_state_recovery_enabled = mdal->get_hardware_state_recovery_enabled();
-  m_timing_session_name = mdal->get_timing_session_name();
+  
   m_managed_endpoint_id = mdal->get_endpoint_id();
 
   TimingController::do_configure(data); // configure hw command connection

--- a/plugins/TimingFanoutController.cpp
+++ b/plugins/TimingFanoutController.cpp
@@ -49,14 +49,11 @@ void
 TimingFanoutController::do_configure(const nlohmann::json& data)
 {
   auto mdal = m_params->cast<dal::TimingFanoutController>(); 
-  if (mdal->get_device_str().empty())
+  if (mdal->get_device().empty())
   {
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
   
-  m_timing_device = mdal->get_device_str();
-  m_hardware_state_recovery_enabled = mdal->get_hardware_state_recovery_enabled();
-  m_timing_session_name = mdal->get_timing_session_name();
   m_device_ready_timeout = std::chrono::milliseconds(mdal->get_device_ready_timeout());
 
   TimingController::do_configure(data); // configure hw command connection

--- a/plugins/TimingPartitionController.cpp
+++ b/plugins/TimingPartitionController.cpp
@@ -60,14 +60,11 @@ TimingPartitionController::do_configure(const nlohmann::json& data)
 {
   auto mdal = m_params->cast<dal::TimingPartitionController>(); 
 
-  if (mdal->get_device_str().empty())
+  if (mdal->get_device().empty())
   {
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
 
-  m_timing_device = mdal->get_device_str();
-  m_hardware_state_recovery_enabled = mdal->get_hardware_state_recovery_enabled();
-  m_timing_session_name = mdal->get_timing_session_name();
   m_managed_partition_id = mdal->get_partition_id();
 
   // parameters against which to compare partition state

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -98,7 +98,6 @@
   <attribute name="falling_edge_mask" description="Falling edge mask for HSI triggering" type="u32" init-value="Unknown"/>
   <attribute name="invert_edge_mask" description="Invert edge mask for HSI triggering" type="u32" init-value="Unknown"/>
   <attribute name="data_source" description="Source of data for HSI triggering" type="string" init-value="Unknown"/>
-  <relationship name="uhal_config" description="Configuration for uhal" class-type="TimingHardwareInterface" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="HSIEventSender">
@@ -109,7 +108,6 @@
   <superclass name="HSIEventSender"/>
   <attribute name="readout_period" description="Hardware device poll perio [us]" type="u64" init-value="1000"/>
   <attribute name="hsi_device_name" type="string" init-value="Unknown"/>
-  <relationship name="uhal_config" description="Configuration for uhal" class-type="TimingHardwareInterface" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
  <class name="TimingController">
@@ -142,12 +140,10 @@
   <superclass name="DaqModule" />
   <attribute name="gather_interval" description="Hardware device data gather interval [us]" type="u64" init-value="1e6"/>
   <attribute name="gather_interval_debug" description="Hardware device data gather debug interval [us]" type="u64" init-value="10e6"/>
-  <attribute name="monitored_device_name_master" description="Name of timing master device to be monitored" type="string" init-value="Unknown"/>
-  <attribute name="monitored_device_names_fanout" description="Names of timing fanout devices to be monitored" type="string" is-multi-value="yes" init-value="FanoutDeviceNames"/>
-  <attribute name="monitored_device_name_endpoint" description="Name of timing endpoint device to be monitored" type="string" init-value="Unknown"/>
-  <attribute name="monitored_device_name_hsi" description="Name of hsi device to be monitored" type="string" init-value="Unknown"/>
-  <attribute name="device_info_connection" description="String of managed hsi device info connection" type="string" init-value="Unknown"/>
-  <relationship name="uhal_config" description="Configuration for uhal" class-type="TimingHardwareInterface" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <attribute name="monitored_device_name_master" description="Name of timing master device to be monitored" type="string" init-value=""/>
+  <attribute name="monitored_device_names_fanout" description="Names of timing fanout devices to be monitored" type="string" is-multi-value="yes" init-value=""/>
+  <attribute name="monitored_device_name_endpoint" description="Name of timing endpoint device to be monitored" type="string" init-value=""/>
+  <attribute name="monitored_device_name_hsi" description="Name of hsi device to be monitored" type="string" init-value=""/>
 </class>
 
  <class name="TimingHardwareManagerPDI">
@@ -159,14 +155,9 @@
  </class>
 
  <class name="EndpointLocation" description="Endpoint location data">
-    <superclass name="TimingMasterController"/>
     <attribute name="fanout_slot" description="Fanout slot of the endpoint" type="u32" init-value="0"/>
     <attribute name="sfp_slot" description="SFP slot of the endpoint" type="u32" init-value="0"/>
     <attribute name="address" description="Address of the endpoint" type="u32" init-value="0"/>
-</class>
-
-<class name="EndpointLocationSet">
-    <relationship name="monitored_endpoints" class-type="EndpointLocation" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
 </class>
 
  <class name="TimingMasterController" description="TimingMasterController configuration">
@@ -175,7 +166,7 @@
   <attribute name="clock_config" description="Path of clock config file" type="string" init-value="Unknown"/>
   <attribute name="soft" description="Soft reset" type="bool" init-value="false"/>
   <attribute name="fanout_mode" description="Fanout mode. -1: none, 0: fanout, 1: standalone" type="string" init-value="Unknown"/>
-  <relationship name="monitoredEndpointsSet" description="List of monitored endpoint addresses" class-type="EndpointLocationSet"  low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
+  <relationship name="monitored_endpoints" description="List of monitored endpoint locations" class-type="EndpointLocation"  low-cc="zero" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>
 
 

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -146,7 +146,7 @@
 
  <class name="TimingHardwareManager" description="TimingHardwareManager configuration">
   <superclass name="TimingHardwareInterface"/>  
-  <attribute name="gather_interval" description="Hardware devicefanout_device_names_vector data gather interval [us]" type="u64" init-value="1e6"/>
+  <attribute name="gather_interval" description="Hardware device data gather interval [us]" type="u64" init-value="1e6"/>
   <attribute name="gather_interval_debug" description="Hardware device data gather debug interval [us]" type="u64" init-value="10e6"/>
   <attribute name="monitored_device_name_master" description="Name of timing master device to be monitored" type="string" init-value="Unknown"/>
   <attribute name="monitored_device_names_fanout" description="Names of timing fanout devices to be monitored" type="string" is-multi-value="yes" init-value="FanoutDeviceNames"/>

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -141,7 +141,7 @@
   <attribute name="endpoint_scan_period" description="Period between endpoint scans. 0 for disabled." type="u32" init-value="0"/>
   <attribute name="clock_config" description="Path of clock config file" type="string" init-value="Unknown"/>
   <attribute name="soft" description="Soft reset" type="bool" init-value="false"/>
-  <attribute name="fanout_mode" description="Fanout mode. -1: none, 0: fanout, 1: standalone" type="string" init-value="Unknown"/>
+  <attribute name="fanout_mode" description="Fanout mode. -1: none, 0: fanout, 1: standalone" type="s32" init-value="Unknown"/>
   <relationship name="monitored_endpoints" description="List of monitored endpoint locations" class-type="EndpointLocation"  low-cc="zero" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>
 

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -121,7 +121,7 @@
 
  <class name="TimingController">
   <superclass name="DaqModule"/>
-  <attribute name="device_str" description="String of managed device name" type="string" init-value="Unknown" is-not-null="yes"/>
+  <attribute name="device" description="String of managed device name" type="string" init-value="Unknown" is-not-null="yes"/>
   <attribute name="hardware_state_recovery_enabled" description="Control flag for hardware state recovery" type="bool" init-value="true"/>
   <attribute name="timing_session_name" description="Name of managed device timing session" type="string" init-value="Unknown"/>
  </class>

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -144,9 +144,9 @@
   <attribute name="connections_file" description="device connections file" type="string" init-value="${TIMING_SHARE}/config/etc/connections.xml"/>
  </class>
 
- <class name="TimingHardwareManager" description="TimingHardwareManager conf parameters">
-  <attribute name="template_for" type="class" init-value="TimingHardwareManagerPDI" is-not-null="yes"/>
-  <attribute name="gather_interval" description="Hardware device data gather interval [us]" type="u64" init-value="1e6"/>
+ <class name="TimingHardwareManager" description="TimingHardwareManager configuration">
+  <superclass name="TimingHardwareInterface"/>  
+  <attribute name="gather_interval" description="Hardware devicefanout_device_names_vector data gather interval [us]" type="u64" init-value="1e6"/>
   <attribute name="gather_interval_debug" description="Hardware device data gather debug interval [us]" type="u64" init-value="10e6"/>
   <attribute name="monitored_device_name_master" description="Name of timing master device to be monitored" type="string" init-value="Unknown"/>
   <attribute name="monitored_device_names_fanout" description="Names of timing fanout devices to be monitored" type="string" is-multi-value="yes" init-value="FanoutDeviceNames"/>
@@ -157,11 +157,11 @@
  </class>
 
  <class name="TimingHardwareManagerPDI">
-  <superclass name="DaqModule"/>
+  <superclass name="TimingHardwareManager"/>
  </class>
 
  <class name="TimingHardwareManagerPDII">
-  <superclass name="DaqModule"/>
+  <superclass name="TimingHardwareManager"/>
  </class>
 
  <class name="TimingMasterController" description="TimingMasterController configuration">
@@ -173,6 +173,14 @@
   <relationship name="monitored_endpoints" description="List of monitored endpoint addresses" class-type="EndpointLocation" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
  </class>
 
+<class name="TimingMasterControllerPDI">
+    <superclass name="TimingMasterController"/>
+</class>
+  
+<class name="TimingMasterControllerPDII">
+    <superclass name="TimingMasterController"/>
+</class>
+  
  <class name="TimingPartitionController" description="TimingPartitionController configuration">
   <superclass name="TimingController"/>
   <attribute name="partition_id" description="Part id number" type="u32" init-value="0"/>

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -155,8 +155,8 @@
  </class>
 
  <class name="EndpointLocation" description="Endpoint location data">
-    <attribute name="fanout_slot" description="Fanout slot of the endpoint" type="u32" init-value="0"/>
-    <attribute name="sfp_slot" description="SFP slot of the endpoint" type="u32" init-value="0"/>
+    <attribute name="fanout_slot" description="Fanout slot of the endpoint" type="s32" init-value="-1"/>
+    <attribute name="sfp_slot" description="SFP slot of the endpoint" type="s32" init-value="-1"/>
     <attribute name="address" description="Address of the endpoint" type="u32" init-value="0"/>
 </class>
 

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -86,30 +86,6 @@
     <file path="schema/confmodel/dunedaq.schema.xml"/>
 </include>
 
- <class name="HSIController">
-  <superclass name="TimingController"/>
-  <attribute name="device" type="string" init-value="Unknown"/>
-  <attribute name="clock_frequency" type="u64" init-value="62500000"/>
-  <attribute name="trigger_rate" type="double" init-value="1"/>
-  <attribute name="address" type="string" init-value="tcp://127.0.0.1:12344"/>
-  <attribute name="partition" type="string" init-value="hsi_readout_test"/>
-  <attribute name="control_hardware_io" description="control flag for controlling hardware io" type="bool" init-value="false"/>
-  <attribute name="rising_edge_mask" description="Rising edge mask for HSI triggering" type="u32" init-value="Unknown"/>
-  <attribute name="falling_edge_mask" description="Falling edge mask for HSI triggering" type="u32" init-value="Unknown"/>
-  <attribute name="invert_edge_mask" description="Invert edge mask for HSI triggering" type="u32" init-value="Unknown"/>
-  <attribute name="data_source" description="Source of data for HSI triggering" type="string" init-value="Unknown"/>
- </class>
-
- <class name="HSIEventSender">
-  <superclass name="DaqModule"/>
- </class>
-
- <class name="HSIReadout">
-  <superclass name="HSIEventSender"/>
-  <attribute name="readout_period" description="Hardware device poll perio [us]" type="u64" init-value="1000"/>
-  <attribute name="hsi_device_name" type="string" init-value="Unknown"/>
- </class>
-
  <class name="TimingController">
   <superclass name="DaqModule"/>
   <attribute name="device" description="String of managed device name" type="string" init-value="Unknown" is-not-null="yes"/>

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -83,7 +83,7 @@
 <info name="" type="" num-of-items="11" oks-format="schema" oks-version="862f2957270" created-by="dianaAntic" created-on="mu2edaq13.fnal.gov" creation-time="20230123T223700" last-modified-by="eflumerf" last-modified-on="ironvirt9.mshome.net" last-modification-time="20240325T173708"/>
 
 <include>
- <file path="schema/confmodel/dunedaq.schema.xml"/>
+    <file path="schema/confmodel/dunedaq.schema.xml"/>
 </include>
 
  <class name="HSIController">
@@ -139,6 +139,7 @@
 
  <class name="TimingHardwareManager" description="TimingHardwareManager configuration">
   <superclass name="TimingHardwareInterface"/>  
+  <superclass name="DaqModule" />
   <attribute name="gather_interval" description="Hardware device data gather interval [us]" type="u64" init-value="1e6"/>
   <attribute name="gather_interval_debug" description="Hardware device data gather debug interval [us]" type="u64" init-value="10e6"/>
   <attribute name="monitored_device_name_master" description="Name of timing master device to be monitored" type="string" init-value="Unknown"/>
@@ -147,7 +148,7 @@
   <attribute name="monitored_device_name_hsi" description="Name of hsi device to be monitored" type="string" init-value="Unknown"/>
   <attribute name="device_info_connection" description="String of managed hsi device info connection" type="string" init-value="Unknown"/>
   <relationship name="uhal_config" description="Configuration for uhal" class-type="TimingHardwareInterface" low-cc="one" high-cc="one" is-composite="no" is-exclusive="no" is-dependent="no"/>
- </class>
+</class>
 
  <class name="TimingHardwareManagerPDI">
   <superclass name="TimingHardwareManager"/>
@@ -164,7 +165,7 @@
     <attribute name="address" description="Address of the endpoint" type="u32" init-value="0"/>
 </class>
 
- <class name="EndpointLocationSet">
+<class name="EndpointLocationSet">
     <relationship name="monitored_endpoints" class-type="EndpointLocation" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
 </class>
 

--- a/schema/timinglibs/timing.schema.xml
+++ b/schema/timinglibs/timing.schema.xml
@@ -86,13 +86,6 @@
  <file path="schema/coredal/dunedaq.schema.xml"/>
 </include>
 
-
- <class name="EndpointLocation" description="Endpoint location data">
-  <attribute name="fanout_slot" description="Fanout slot of the endpoint" type="u32" init-value="0"/>
-  <attribute name="sfp_slot" description="SFP slot of the endpoint" type="u32" init-value="0"/>
-  <attribute name="address" description="Address of the endpoint" type="u32" init-value="0"/>
- </class>
-
  <class name="HSIController">
   <superclass name="TimingController"/>
   <attribute name="device" type="string" init-value="Unknown"/>
@@ -164,14 +157,30 @@
   <superclass name="TimingHardwareManager"/>
  </class>
 
+ <class name="EndpointLocation" description="Endpoint location data">
+    <superclass name="TimingMasterController"/>
+    <attribute name="fanout_slot" description="Fanout slot of the endpoint" type="u32" init-value="0"/>
+    <attribute name="sfp_slot" description="SFP slot of the endpoint" type="u32" init-value="0"/>
+    <attribute name="address" description="Address of the endpoint" type="u32" init-value="0"/>
+</class>
+
+ <class name="EndpointLocationSet">
+    <relationship name="monitored_endpoints" class-type="EndpointLocation" low-cc="one" high-cc="many" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
+</class>
+
  <class name="TimingMasterController" description="TimingMasterController configuration">
   <superclass name="TimingController"/>
   <attribute name="endpoint_scan_period" description="Period between endpoint scans. 0 for disabled." type="u32" init-value="0"/>
   <attribute name="clock_config" description="Path of clock config file" type="string" init-value="Unknown"/>
   <attribute name="soft" description="Soft reset" type="bool" init-value="false"/>
   <attribute name="fanout_mode" description="Fanout mode. -1: none, 0: fanout, 1: standalone" type="string" init-value="Unknown"/>
-  <relationship name="monitored_endpoints" description="List of monitored endpoint addresses" class-type="EndpointLocation" low-cc="one" high-cc="many" is-composite="no" is-exclusive="no" is-dependent="no"/>
+  <relationship name="monitoredEndpointsSet" description="List of monitored endpoint addresses" class-type="EndpointLocationSet"  low-cc="one" high-cc="one" is-composite="yes" is-exclusive="no" is-dependent="yes"/>
  </class>
+
+
+<class name="TimingMasterEndpointScanPayload">
+    <attribute name="endpoints" type="class" init-value="EndpointLocation" />
+</class>
 
 <class name="TimingMasterControllerPDI">
     <superclass name="TimingMasterController"/>

--- a/src/TimingController.cpp
+++ b/src/TimingController.cpp
@@ -61,6 +61,12 @@ TimingController::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg)
 void
 TimingController::do_configure(const nlohmann::json&)
 {
+  auto mdal = m_params->cast<dal::TimingController>(); 
+
+  m_timing_device = mdal->get_device();
+  m_hardware_state_recovery_enabled = mdal->get_hardware_state_recovery_enabled();
+  m_timing_session_name = mdal->get_timing_session_name();
+
   if (m_timing_session_name.empty())
   {
     m_hw_command_sender = iomanager::IOManager::get()->get_sender<timingcmd::TimingHwCmd>(m_hw_command_out_connection);

--- a/src/TimingController.cpp
+++ b/src/TimingController.cpp
@@ -67,6 +67,11 @@ TimingController::do_configure(const nlohmann::json&)
   m_hardware_state_recovery_enabled = mdal->get_hardware_state_recovery_enabled();
   m_timing_session_name = mdal->get_timing_session_name();
 
+  if (m_timing_device.empty())
+  {
+    throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
+  }
+
   if (m_timing_session_name.empty())
   {
     m_hw_command_sender = iomanager::IOManager::get()->get_sender<timingcmd::TimingHwCmd>(m_hw_command_out_connection);

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -389,7 +389,7 @@ void TimingHardwareManager::perform_endpoint_scan(const timingcmd::TimingHwCmd& 
 
     std::unique_lock<std::mutex> master_sfp_lock(master_sfp_mutex);
 
-    TLOG_DEBUG(1) << get_name() << ": " << hw_cmd.device << " master_endpoint_scan starting: ept adr: " << endpoint_address << ", ept sfp: " << sfp_slot;
+    TLOG_DEBUG(1) << get_name() << ": " << hw_cmd.device << " master_endpoint_scan starting: ept adr: " << endpoint_address << ", ept sfp: " << sfp_slot << ", fanout slot: " << fanout_slot;
 
     auto master_design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
 

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -71,7 +71,7 @@ TimingHardwareManager::conf(const nlohmann::json&)
   m_rejected_hw_commands_counter = 0;
   m_failed_hw_commands_counter = 0;
 
-  configure_uhal(m_params->get_uhal_config()); // configure hw ipbus connection
+  configure_uhal(m_params); // configure hw ipbus connection
 
   m_hw_command_receiver->add_callback(std::bind(&TimingHardwareManager::process_hardware_command, this, std::placeholders::_1));
 

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -61,8 +61,14 @@ TimingMasterController::do_configure(const nlohmann::json& data)
   {
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
-  
-  // m_monitored_endpoint_locations = mdal->get_monitored_endpoints();
+
+  // for (auto endpoints : mdal->get_monitoredEndpointsSet()->get_monitored_endpoints()) {
+  //   m_monitored_endpoint_locations.push_back(endpoints->get_fanout_slot());
+  //   m_monitored_endpoint_locations.push_back(endpoints->get_sfp_slot());
+  //   m_monitored_endpoint_locations.push_back(endpoints->get_address());
+  // }
+
+  m_monitored_endpoint_locations = mdal->get_monitoredEndpointsSet()->get_monitored_endpoints()->address();
 
   TimingController::do_configure(data); // configure hw command connection
 
@@ -224,7 +230,10 @@ TimingMasterController::endpoint_scan(std::atomic<bool>& running_flag)
 
     timingcmd::TimingMasterEndpointScanPayload cmd_payload;
     cmd_payload.endpoints = m_monitored_endpoint_locations;
-    
+
+    // dal::TimingMasterController::TimingMasterEndpointScanPayload cmd_payload;
+    // cmd_payload.endpoints = m_monitored_endpoint_locations;
+
     hw_cmd.payload = cmd_payload;
     send_hw_cmd(std::move(hw_cmd));
 

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -9,6 +9,7 @@
 
 #include "TimingMasterController.hpp"
 #include "timinglibs/dal/EndpointLocationSet.hpp"
+#include "timinglibs/dal/EndpointLocation.hpp"
 #include "timinglibs/dal/TimingMasterController.hpp"
 
 #include "timinglibs/timingmastercontroller/Nljs.hpp"
@@ -63,13 +64,15 @@ TimingMasterController::do_configure(const nlohmann::json& data)
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
 
-  // for (auto endpoints : mdal->get_monitoredEndpointsSet()->get_monitored_endpoints()) {
-  //   m_monitored_endpoint_locations.push_back(endpoints->get_fanout_slot());
-  //   m_monitored_endpoint_locations.push_back(endpoints->get_sfp_slot());
-  //   m_monitored_endpoint_locations.push_back(endpoints->get_address());
-  // }
+  auto monitored_endpoints = mdal->get_monitoredEndpointsSet()->get_monitored_endpoints();
 
-  m_monitored_endpoint_locations = mdal->get_monitoredEndpointsSet()->get_monitored_endpoints();
+   for (auto endpoint : monitored_endpoints) {
+    timingcmd::EndpointLocation endpoint_location;
+    endpoint_location.address = endpoint->get_address();
+    endpoint_location.fanout_slot = endpoint->get_fanout_slot();
+    endpoint_location.sfp_slot = endpoint->get_sfp_slot();
+    m_monitored_endpoint_locations.push_back(endpoint_location);
+   }
 
   TimingController::do_configure(data); // configure hw command connection
 

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -8,7 +8,6 @@
  */
 
 #include "TimingMasterController.hpp"
-#include "timinglibs/dal/EndpointLocationSet.hpp"
 #include "timinglibs/dal/EndpointLocation.hpp"
 #include "timinglibs/dal/TimingMasterController.hpp"
 

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -64,7 +64,7 @@ TimingMasterController::do_configure(const nlohmann::json& data)
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
 
-  auto monitored_endpoints = mdal->get_monitoredEndpointsSet()->get_monitored_endpoints();
+  auto monitored_endpoints = mdal->get_monitored_endpoints();
 
    for (auto endpoint : monitored_endpoints) {
     timingcmd::EndpointLocation endpoint_location;

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "TimingMasterController.hpp"
+#include "timinglibs/dal/EndpointLocationSet.hpp"
 #include "timinglibs/dal/TimingMasterController.hpp"
 
 #include "timinglibs/timingmastercontroller/Nljs.hpp"
@@ -68,7 +69,7 @@ TimingMasterController::do_configure(const nlohmann::json& data)
   //   m_monitored_endpoint_locations.push_back(endpoints->get_address());
   // }
 
-  m_monitored_endpoint_locations = mdal->get_monitoredEndpointsSet()->get_monitored_endpoints()->address();
+  m_monitored_endpoint_locations = mdal->get_monitoredEndpointsSet()->get_monitored_endpoints();
 
   TimingController::do_configure(data); // configure hw command connection
 

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -55,16 +55,13 @@ TimingMasterController::TimingMasterController(const std::string& name)
 void
 TimingMasterController::do_configure(const nlohmann::json& data)
 {
-  // auto conf = data.get<timingmastercontroller::ConfParams>();
   auto mdal = m_params->cast<dal::TimingMasterController>(); 
 
-  if (mdal->get_device_str().empty())
+  if (mdal->get_device().empty())
   {
     throw UHALDeviceNameIssue(ERS_HERE, "Device name should not be empty");
   }
-  m_timing_device = mdal->get_device_str();
-  m_hardware_state_recovery_enabled = mdal->get_hardware_state_recovery_enabled();
-  m_timing_session_name = mdal->get_timing_session_name();
+  
   // m_monitored_endpoint_locations = mdal->get_monitored_endpoints();
 
   TimingController::do_configure(data); // configure hw command connection

--- a/src/TimingMasterController.hpp
+++ b/src/TimingMasterController.hpp
@@ -13,6 +13,7 @@
 #define TIMINGLIBS_PLUGINS_TIMINGMASTERCONTROLLER_HPP_
 
 #include "timinglibs/TimingController.hpp"
+#include "timinglibs/dal/TimingMasterController.hpp"
 
 #include "timinglibs/timingcmd/Nljs.hpp"
 #include "timinglibs/timingcmd/Structs.hpp"

--- a/test/boot.json
+++ b/test/boot.json
@@ -1,91 +1,91 @@
 {
-    "apps": {
-        "thi": {
-            "exec": "daq_application_ssh",
-            "host": "thi",
-            "port": 3333
-        },
-        "tmc": {
-            "exec": "daq_application_ssh",
-            "host": "tmc",
-            "port": 3334
-        }
+  "apps": {
+    "thi": {
+      "exec": "daq_application_ssh",
+      "host": "local",
+      "port": 3333
     },
-    "env": {
-        "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv_ifset",
-        "DUNEDAQ_ERS_ERROR": "erstrace,throttle,lstdout",
-        "DUNEDAQ_ERS_FATAL": "erstrace,lstdout",
-        "DUNEDAQ_ERS_INFO": "erstrace,throttle,lstdout",
-        "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv:1",
-        "DUNEDAQ_ERS_WARNING": "erstrace,throttle,lstdout"
-    },
-    "exec": {
-        "consvc_ssh": {
-            "args": [
-                "--bind=0.0.0.0:{APP_PORT}",
-                "--workers=1",
-                "--worker-class=gthread",
-                "--threads=2",
-                "--timeout=0",
-                "--pid={APP_NAME}_{APP_PORT}.pid",
-                "connection-service.connection-flask:app"
-            ],
-            "cmd": "gunicorn",
-            "env": {
-                "CONNECTION_FLASK_DEBUG": "getenv:2",
-                "PATH": "getenv",
-                "PYTHONPATH": "getenv"
-            }
-        },
-        "daq_application_ssh": {
-            "args": [
-                "--name",
-                "{APP_NAME}",
-                "-c",
-                "{CMD_FAC}",
-                "-i",
-                "{INFO_SVC}",
-                "--configurationService",
-                "oksconflibs:config/timing.data.xml"
-            ],
-            "cmd": "daq_application",
-            "comment": "Application profile using PATH variables (lower start time)",
-            "env": {
-                "CET_PLUGIN_PATH": "getenv",
-                "CMD_FAC": "rest://localhost:{APP_PORT}",
-                "CONNECTION_SERVER": "localhost",
-                "DETCHANNELMAPS_SHARE": "getenv",
-                "DUNEDAQ_SHARE_PATH": "getenv",
-                "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
-                "LD_LIBRARY_PATH": "getenv",
-                "PATH": "getenv",
-                "TIMING_SHARE": "getenv",
-                "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}",
-		"DUNEDAQ_SHARE_PATH": "getenv"
-            }
-        }
-    },
-    "external_connections": [],
-    "hosts-ctrl": {
-        "connectionservice": "localhost",
-        "thi": "localhost",
-        "tmc": "localhost"
-    },
-    "hosts-data": {
-        "thi": "localhost",
-        "tmc": "localhost"
-    },
-    "response_listener": {
-        "port": 56789
-    },
-    "services": {
-        "connectionservice": {
-            "exec": "consvc_ssh",
-            "host": "connectionservice",
-            "port": 5000,
-            "update-env": {
-                "CONNECTION_PORT": "{APP_PORT}"
-            }
-        }
+    "tmc": {
+      "exec": "daq_application_ssh",
+      "host": "local",
+      "port": 3334
     }
+  },
+  "env": {
+    "DUNEDAQ_ERS_STREAM_LIBS": "erskafka",
+    "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv_ifset",
+    "DUNEDAQ_ERS_ERROR": "erstrace,throttle,lstdout",
+    "DUNEDAQ_ERS_FATAL": "erstrace,lstdout",
+    "DUNEDAQ_ERS_INFO": "erstrace,throttle,lstdout",
+    "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv:1",
+    "DUNEDAQ_ERS_WARNING": "erstrace,throttle,lstdout"
+  },
+  "exec": {
+    "consvc_ssh": {
+      "args": [
+        "--bind=0.0.0.0:{APP_PORT}",
+        "--workers=1",
+        "--worker-class=gthread",
+        "--threads=2",
+        "--timeout=0",
+        "--pid={APP_NAME}_{APP_PORT}.pid",
+        "connection-service.connection-flask:app"
+      ],
+      "cmd": "gunicorn",
+      "env": {
+        "CONNECTION_FLASK_DEBUG": "getenv:2",
+        "PATH": "getenv",
+        "PYTHONPATH": "getenv"
+      }
+    },
+    "daq_application_ssh": {
+      "args": [
+        "--name",
+        "{APP_NAME}",
+        "-c",
+        "{CMD_FAC}",
+        "-i",
+        "{INFO_SVC}",
+        "--configurationService",
+        "oksconflibs:config/timing.data.xml"
+      ],
+      "cmd": "daq_application",
+      "comment": "Application profile using PATH variables (lower start time)",
+      "env": {
+        "CET_PLUGIN_PATH": "getenv",
+        "CMD_FAC": "rest://localhost:{APP_PORT}",
+        "CONNECTION_SERVER": "localhost",
+        "DETCHANNELMAPS_SHARE": "getenv",
+        "DUNEDAQ_SHARE_PATH": "getenv",
+        "DUNEDAQ_DB_PATH": "getenv",
+        "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
+        "TIMING_SHARE": "disabled",
+	"LD_LIBRARY_PATH": "getenv",
+        "PATH": "getenv",
+        "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}"
+      }
+    }
+  },
+  "external_connections": [],
+  "hosts-ctrl": {
+    "connectionservice": "localhost",
+    "local": "localhost"
+  },
+  "hosts-data": {
+    "local": "localhost"
+  },
+  "response_listener": {
+    "port": 56789
+  },
+  "services": {
+    "connectionservice": {
+      "exec": "consvc_ssh",
+      "host": "connectionservice",
+      "port": 15000,
+      "update-env": {
+        "CONNECTION_PORT": "{APP_PORT}"
+      }
+    }
+  }
 }
+

--- a/test/boot.json
+++ b/test/boot.json
@@ -46,34 +46,34 @@
                 "-i",
                 "{INFO_SVC}",
                 "--configurationService",
-                "oksconflibs:config/timing.data.xml"
+                "oksconfig:config/timing.data.xml"
             ],
             "cmd": "daq_application",
             "comment": "Application profile using PATH variables (lower start time)",
             "env": {
                 "CET_PLUGIN_PATH": "getenv",
                 "CMD_FAC": "rest://localhost:{APP_PORT}",
-                "CONNECTION_SERVER": "localhost",
+                "CONNECTION_SERVER": "kipper.phy.bris.ac.uk",
                 "DETCHANNELMAPS_SHARE": "getenv",
+                "DUNEDAQ_DB_PATH": "getenv",
                 "DUNEDAQ_SHARE_PATH": "getenv",
                 "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
                 "LD_LIBRARY_PATH": "getenv",
                 "PATH": "getenv",
                 "TIMING_SHARE": "getenv",
-                "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}",
-		"DUNEDAQ_SHARE_PATH": "getenv"
+                "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}"
             }
         }
     },
     "external_connections": [],
     "hosts-ctrl": {
-        "connectionservice": "localhost",
-        "thi": "localhost",
-        "tmc": "localhost"
+        "connectionservice": "kipper.phy.bris.ac.uk",
+        "thi": "kipper.phy.bris.ac.uk",
+        "tmc": "kipper.phy.bris.ac.uk"
     },
     "hosts-data": {
-        "thi": "localhost",
-        "tmc": "localhost"
+        "thi": "kipper.phy.bris.ac.uk",
+        "tmc": "kipper.phy.bris.ac.uk"
     },
     "response_listener": {
         "port": 56789

--- a/test/boot.json
+++ b/test/boot.json
@@ -1,0 +1,91 @@
+{
+    "apps": {
+        "thi": {
+            "exec": "daq_application_ssh",
+            "host": "thi",
+            "port": 3333
+        },
+        "tmc": {
+            "exec": "daq_application_ssh",
+            "host": "tmc",
+            "port": 3334
+        }
+    },
+    "env": {
+        "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv_ifset",
+        "DUNEDAQ_ERS_ERROR": "erstrace,throttle,lstdout",
+        "DUNEDAQ_ERS_FATAL": "erstrace,lstdout",
+        "DUNEDAQ_ERS_INFO": "erstrace,throttle,lstdout",
+        "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv:1",
+        "DUNEDAQ_ERS_WARNING": "erstrace,throttle,lstdout"
+    },
+    "exec": {
+        "consvc_ssh": {
+            "args": [
+                "--bind=0.0.0.0:{APP_PORT}",
+                "--workers=1",
+                "--worker-class=gthread",
+                "--threads=2",
+                "--timeout=0",
+                "--pid={APP_NAME}_{APP_PORT}.pid",
+                "connection-service.connection-flask:app"
+            ],
+            "cmd": "gunicorn",
+            "env": {
+                "CONNECTION_FLASK_DEBUG": "getenv:2",
+                "PATH": "getenv",
+                "PYTHONPATH": "getenv"
+            }
+        },
+        "daq_application_ssh": {
+            "args": [
+                "--name",
+                "{APP_NAME}",
+                "-c",
+                "{CMD_FAC}",
+                "-i",
+                "{INFO_SVC}",
+                "--configurationService",
+                "oksconflibs:config/timing.data.xml"
+            ],
+            "cmd": "daq_application",
+            "comment": "Application profile using PATH variables (lower start time)",
+            "env": {
+                "CET_PLUGIN_PATH": "getenv",
+                "CMD_FAC": "rest://localhost:{APP_PORT}",
+                "CONNECTION_SERVER": "localhost",
+                "DETCHANNELMAPS_SHARE": "getenv",
+                "DUNEDAQ_SHARE_PATH": "getenv",
+                "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
+                "LD_LIBRARY_PATH": "getenv",
+                "PATH": "getenv",
+                "TIMING_SHARE": "getenv",
+                "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}",
+		"DUNEDAQ_SHARE_PATH": "getenv"
+            }
+        }
+    },
+    "external_connections": [],
+    "hosts-ctrl": {
+        "connectionservice": "localhost",
+        "thi": "localhost",
+        "tmc": "localhost"
+    },
+    "hosts-data": {
+        "thi": "localhost",
+        "tmc": "localhost"
+    },
+    "response_listener": {
+        "port": 56789
+    },
+    "services": {
+        "connectionservice": {
+            "exec": "consvc_ssh",
+            "host": "connectionservice",
+            "port": 5000,
+            "update-env": {
+                "CONNECTION_PORT": "{APP_PORT}"
+            }
+        }
+    }
+}

--- a/test/boot.json
+++ b/test/boot.json
@@ -46,14 +46,14 @@
                 "-i",
                 "{INFO_SVC}",
                 "--configurationService",
-                "oksconfig:config/timing.data.xml"
+                "oksconflibs:config/timing.data.xml"
             ],
             "cmd": "daq_application",
             "comment": "Application profile using PATH variables (lower start time)",
             "env": {
                 "CET_PLUGIN_PATH": "getenv",
                 "CMD_FAC": "rest://localhost:{APP_PORT}",
-                "CONNECTION_SERVER": "kipper.phy.bris.ac.uk",
+                "CONNECTION_SERVER": "localhost",
                 "DETCHANNELMAPS_SHARE": "getenv",
                 "DUNEDAQ_DB_PATH": "getenv",
                 "DUNEDAQ_SHARE_PATH": "getenv",
@@ -67,13 +67,13 @@
     },
     "external_connections": [],
     "hosts-ctrl": {
-        "connectionservice": "kipper.phy.bris.ac.uk",
-        "thi": "kipper.phy.bris.ac.uk",
-        "tmc": "kipper.phy.bris.ac.uk"
+        "connectionservice": "localhost",
+        "thi": "localhost",
+        "tmc": "localhost"
     },
     "hosts-data": {
-        "thi": "kipper.phy.bris.ac.uk",
-        "tmc": "kipper.phy.bris.ac.uk"
+        "thi": "localhost",
+        "tmc": "localhost"
     },
     "response_listener": {
         "port": 56789


### PR DESCRIPTION
To verify the functionality of the OKS configuration, the testing of nanotimingrc on real hardware was required. 

This PR adds the required database file for setting up the minimal OKS configuration for a successful RC run.

To test, I ran the following command on kipper in a recent work env `NFD_DEV_240507_C8`: 
`nanotimingrc --partition-number 7 timinglibs/test_config/ test-session`
making sure that the name of the test session matches the name given in this object: `<obj class="Session" id="test-session">` in the data file.
The folder ` timinglibs/test_config/` must include a `boot.json` file which contains the necessary setup for the RC run - the following is the json content I used:
```
{
    "apps": {
        "thi": {
            "exec": "daq_application_ssh",
            "host": "thi",
            "port": 3333
        },
        "tmc": {
            "exec": "daq_application_ssh",
            "host": "tmc",
            "port": 3334
        }
    },
    "env": {
        "DUNEDAQ_ERS_DEBUG_LEVEL": "getenv_ifset",
        "DUNEDAQ_ERS_ERROR": "erstrace,throttle,lstdout",
        "DUNEDAQ_ERS_FATAL": "erstrace,lstdout",
        "DUNEDAQ_ERS_INFO": "erstrace,throttle,lstdout",
        "DUNEDAQ_ERS_VERBOSITY_LEVEL": "getenv:1",
        "DUNEDAQ_ERS_WARNING": "erstrace,throttle,lstdout"
    },
    "exec": {
        "consvc_ssh": {
            "args": [
                "--bind=0.0.0.0:{APP_PORT}",
                "--workers=1",
                "--worker-class=gthread",
                "--threads=2",
                "--timeout=0",
                "--pid={APP_NAME}_{APP_PORT}.pid",
                "connection-service.connection-flask:app"
            ],
            "cmd": "gunicorn",
            "env": {
                "CONNECTION_FLASK_DEBUG": "getenv:2",
                "PATH": "getenv",
                "PYTHONPATH": "getenv"
            }
        },
        "daq_application_ssh": {
            "args": [
                "--name",
                "{APP_NAME}",
                "-c",
                "{CMD_FAC}",
                "-i",
                "{INFO_SVC}",
                "--configurationService",
                "oksconfig:config/timing.data.xml"
            ],
            "cmd": "daq_application",
            "comment": "Application profile using PATH variables (lower start time)",
            "env": {
                "CET_PLUGIN_PATH": "getenv",
                "CMD_FAC": "rest://localhost:{APP_PORT}",
                "CONNECTION_SERVER": "kipper.phy.bris.ac.uk",
                "DETCHANNELMAPS_SHARE": "getenv",
                "DUNEDAQ_DB_PATH": "getenv",
                "DUNEDAQ_SHARE_PATH": "getenv",
                "INFO_SVC": "file://info_{APP_NAME}_{APP_PORT}.json",
                "LD_LIBRARY_PATH": "getenv",
                "PATH": "getenv",
                "TIMING_SHARE": "getenv",
                "TRACE_FILE": "getenv:/tmp/trace_buffer_{APP_HOST}_{DUNEDAQ_PARTITION}"
            }
        }
    },
    "external_connections": [],
    "hosts-ctrl": {
        "connectionservice": "kipper.phy.bris.ac.uk",
        "thi": "kipper.phy.bris.ac.uk",
        "tmc": "kipper.phy.bris.ac.uk"
    },
    "hosts-data": {
        "thi": "kipper.phy.bris.ac.uk",
        "tmc": "kipper.phy.bris.ac.uk"
    },
    "response_listener": {
        "port": 56789
    },
    "services": {
        "connectionservice": {
            "exec": "consvc_ssh",
            "host": "connectionservice",
            "port": 5000,
            "update-env": {
                "CONNECTION_PORT": "{APP_PORT}"
            }
        }
    }
}
```
Also, for the `TimingHardwareInterface` object, a `connections_file` is required and this is the content of the one whose path I used: 
```
<?xml version="1.0" encoding="UTF-8"?>

<connections>
  <connection id="TEST_CTL"          uri="ipbusudp-2.0://192.168.200.16:50001" address_table="file://${TIMING_SHARE}/config/etc/addrtab/v7xx/master/top.xml" />
  <connection id="TEST_EPT"          uri="ipbusudp-2.0://192.168.200.41:50001" address_table="file://${TIMING_SHARE}/config/etc/addrtab/v7xx/endpoint_fmc/top.xml" />
</connections>
```
which is a Controller-Endpoint connection that's currently connected and ping-able in the Bristol lab. 