### PR TITLE
Diana/periodic cmds

### DIFF
--- a/include/timinglibs/TimingIssues.hpp
+++ b/include/timinglibs/TimingIssues.hpp
@@ -100,6 +100,13 @@ ERS_DECLARE_ISSUE_BASE(timinglibs,
                        ((std::string)device))
 
 ERS_DECLARE_ISSUE_BASE(timinglibs,
+                       InvalidFLCommandID,
+                       timinglibs::FailedToExecuteHardwareCommand,
+                       " Tried to execture invalid fixed lengh command " << fl_cmd_id << ". ",
+                       ((std::string)hw_cmd_id)((std::string)device),
+                       ((int)fl_cmd_id))
+
+ERS_DECLARE_ISSUE_BASE(timinglibs,
                        TimingHardwareCommandRegistrationFailed,
                        appfwk::CommandRegistrationFailed,
                        " Failed to register timing hardware command with ID: " << cmd,

--- a/plugins/TimingHardwareManagerPDII.cpp
+++ b/plugins/TimingHardwareManagerPDII.cpp
@@ -111,6 +111,9 @@ TimingHardwareManagerPDII::register_master_hw_commands_for_design()
   register_timing_hw_command("set_endpoint_delay", &TimingHardwareManagerPDII::set_endpoint_delay);
   register_timing_hw_command("send_fl_command", &TimingHardwareManagerPDII::send_fl_cmd);
   register_timing_hw_command("master_endpoint_scan", &TimingHardwareManagerPDII::master_endpoint_scan);
+  register_timing_hw_command("master_start_periodic_fl_commands", &TimingHardwareManagerPDII::start_send_periodic_fl_cmd);
+  register_timing_hw_command("master_stop_periodic_fl_commands", &TimingHardwareManagerPDII::stop_send_periodic_fl_cmd);
+
 }
 
 void

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -42,7 +42,7 @@ def generate_timing_rc_cmds(
                                                                 rate=10,
                                                                 poisson=False))])),
         ("master_stop_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStopPeriodicFLCmd(
-                                                                channel=0))])),
+                                                                channel=256))])),
         ]
 
     data_dir = f"{JSON_DIR}/data"

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -27,8 +27,7 @@ def generate_timing_rc_cmds(
         ("master_send_fl_command",    acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSendFLCmdCmdPayload(
                                                                 fl_cmd_id=0x1,
                                                                 channel=0,
-                                                                number_of_commands_to_send=1,
-                                                                rate=10))])),
+                                                                number_of_commands_to_send=1))])),
         ("master_set_endpoint_delay", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSetEndpointDelayCmdPayload(
                                                                 address=0,
                                                                 coarse_delay=0,
@@ -41,8 +40,7 @@ def generate_timing_rc_cmds(
                                                                 fl_cmd_id=0x1,
                                                                 channel=0,
                                                                 rate=10,
-                                                                poisson=False,
-                                                                clock_frequency_hz=10))])),
+                                                                poisson=False))])),
         ("master_stop_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStopPeriodicFLCmd(
                                                                 channel=0))])),
         ]

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -37,8 +37,13 @@ def generate_timing_rc_cmds(
                                                                 measure_rtt=False,
                                                                 control_sfp=False,
                                                                 sfp_mux=-1))])),
-        ("master_send_periodic_command_sends", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSendPeriodicCommand(
-                                                                cmd_id=0x1,
+        ("master_start_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStartPeriodicFLCmd(
+                                                                fl_cmd_id=0x1,
+                                                                channel=0,
+                                                                number_of_commands_to_send=1,
+                                                                rate=10))])),
+        ("master_stop_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStopPeriodicFLCmd(
+                                                                fl_cmd_id=0x1,
                                                                 channel=0,
                                                                 number_of_commands_to_send=1,
                                                                 rate=10))])),

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -37,7 +37,7 @@ def generate_timing_rc_cmds(
                                                                 control_sfp=False,
                                                                 sfp_mux=-1))])),
         ("master_start_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStartPeriodicFLCmd(
-                                                                fl_cmd_id=0x1,
+                                                                fl_cmd_id=256,
                                                                 channel=0,
                                                                 rate=10,
                                                                 poisson=False))])),

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -26,7 +26,7 @@ def generate_timing_rc_cmds(
     cmds = [
         ("master_send_fl_command",    acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSendFLCmdCmdPayload(
                                                                 fl_cmd_id=0x1,
-                                                                channel=0,
+                                                                channel=256,
                                                                 number_of_commands_to_send=1))])),
         ("master_set_endpoint_delay", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSetEndpointDelayCmdPayload(
                                                                 address=0,
@@ -38,7 +38,7 @@ def generate_timing_rc_cmds(
                                                                 sfp_mux=-1))])),
         ("master_start_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStartPeriodicFLCmd(
                                                                 fl_cmd_id=256,
-                                                                channel=0,
+                                                                channel=256,
                                                                 rate=10,
                                                                 poisson=False))])),
         ("master_stop_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStopPeriodicFLCmd(

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -40,13 +40,11 @@ def generate_timing_rc_cmds(
         ("master_start_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStartPeriodicFLCmd(
                                                                 fl_cmd_id=0x1,
                                                                 channel=0,
-                                                                number_of_commands_to_send=1,
-                                                                rate=10))])),
+                                                                rate=10,
+                                                                poisson=False,
+                                                                clock_frequency_hz=10))])),
         ("master_stop_periodic_fl_commands", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterStopPeriodicFLCmd(
-                                                                fl_cmd_id=0x1,
-                                                                channel=0,
-                                                                number_of_commands_to_send=1,
-                                                                rate=10))])),
+                                                                channel=0))])),
         ]
 
     data_dir = f"{JSON_DIR}/data"

--- a/python/timinglibs/timing_rc_cmd_gen.py
+++ b/python/timinglibs/timing_rc_cmd_gen.py
@@ -27,7 +27,8 @@ def generate_timing_rc_cmds(
         ("master_send_fl_command",    acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSendFLCmdCmdPayload(
                                                                 fl_cmd_id=0x1,
                                                                 channel=0,
-                                                                number_of_commands_to_send=1))])),
+                                                                number_of_commands_to_send=1,
+                                                                rate=10))])),
         ("master_set_endpoint_delay", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSetEndpointDelayCmdPayload(
                                                                 address=0,
                                                                 coarse_delay=0,
@@ -36,6 +37,11 @@ def generate_timing_rc_cmds(
                                                                 measure_rtt=False,
                                                                 control_sfp=False,
                                                                 sfp_mux=-1))])),
+        ("master_send_periodic_command_sends", acmd([ (MASTER_CONTROLLER_MOD_NAME, tcmd.TimingMasterSendPeriodicCommand(
+                                                                cmd_id=0x1,
+                                                                channel=0,
+                                                                number_of_commands_to_send=1,
+                                                                rate=10))])),
         ]
 
     data_dir = f"{JSON_DIR}/data"

--- a/schema/timinglibs/timingcmd.jsonnet
+++ b/schema/timinglibs/timingcmd.jsonnet
@@ -103,6 +103,8 @@ local timingcmd = {
             doc="Channel on which to send command"),
         s.field("number_of_commands_to_send", self.uint_data,
             doc="How many commands to send"),
+        s.field("rate", self.uint_data,
+            doc="Rate of command sends"),
     ], doc="Structure for payload of endpoint configure commands"),
 
     timing_master_set_endpoint_delay_cmd_payload: s.record("TimingMasterSetEndpointDelayCmdPayload",[
@@ -120,6 +122,17 @@ local timingcmd = {
             doc="Control SFP or not"),
         s.field("sfp_mux", self.int_data,
             doc="Mux to endpoint (or not)"),
+    ], doc="Structure for payload of timing master set endpoint delay command"),
+
+    timing_master_set_periodic_command_sends: s.record("TimingMasterSendPeriodicCommand",[
+        s.field("cmd_id", self.uint_data,
+            doc="ID of target endpoint"),
+        s.field("channel", self.uint_data,
+            doc="Channel on which to send command"),
+        s.field("number_of_commands_to_send", self.uint_data,
+            doc="How many commands to send"),
+        s.field("rate", self.uint_data,
+            doc="Rate of command sends"),
     ], doc="Structure for payload of timing master set endpoint delay command"),
 
     timing_endpoint_location_data: s.record("EndpointLocation", [

--- a/schema/timinglibs/timingcmd.jsonnet
+++ b/schema/timinglibs/timingcmd.jsonnet
@@ -103,8 +103,6 @@ local timingcmd = {
             doc="Channel on which to send command"),
         s.field("number_of_commands_to_send", self.uint_data,
             doc="How many commands to send"),
-        s.field("rate", self.uint_data,
-            doc="Rate of command sends"),
     ], doc="Structure for payload of endpoint configure commands"),
 
     timing_master_set_endpoint_delay_cmd_payload: s.record("TimingMasterSetEndpointDelayCmdPayload",[
@@ -133,8 +131,6 @@ local timingcmd = {
             doc="Rate of command sends"),
         s.field("poisson", self.bool_data,
             doc="Poisson"),
-        s.field("clock_frequency_hz", self.uint_data,
-            doc="Clock frequency"),
     ], doc="Structure for sending of periodic timing master commands"),
 
     timing_master_stop_periodic_command_sends: s.record("TimingMasterStopPeriodicFLCmd",[

--- a/schema/timinglibs/timingcmd.jsonnet
+++ b/schema/timinglibs/timingcmd.jsonnet
@@ -124,16 +124,23 @@ local timingcmd = {
             doc="Mux to endpoint (or not)"),
     ], doc="Structure for payload of timing master set endpoint delay command"),
 
-    timing_master_set_periodic_command_sends: s.record("TimingMasterSendPeriodicCommand",[
-        s.field("cmd_id", self.uint_data,
+    timing_master_start_periodic_command_sends: s.record("TimingMasterStartPeriodicFLCmd",[
+        s.field("fl_cmd_id", self.uint_data,
             doc="ID of target endpoint"),
         s.field("channel", self.uint_data,
             doc="Channel on which to send command"),
-        s.field("number_of_commands_to_send", self.uint_data,
-            doc="How many commands to send"),
-        s.field("rate", self.uint_data,
+        s.field("rate", self.double_data,
             doc="Rate of command sends"),
-    ], doc="Structure for payload of timing master set endpoint delay command"),
+        s.field("poisson", self.bool_data,
+            doc="Poisson"),
+        s.field("clock_frequency_hz", self.uint_data,
+            doc="Clock frequency"),
+    ], doc="Structure for sending of periodic timing master commands"),
+
+    timing_master_stop_periodic_command_sends: s.record("TimingMasterStopPeriodicFLCmd",[
+        s.field("channel", self.uint_data,
+            doc="Channel on which to send command"),
+    ], doc="Structure for stopping of periodic timing master commands"),
 
     timing_endpoint_location_data: s.record("EndpointLocation", [
         s.field("fanout_slot", self.int_data,

--- a/schema/timinglibs/timingmastercontrollerinfo.jsonnet
+++ b/schema/timinglibs/timingmastercontrollerinfo.jsonnet
@@ -13,6 +13,11 @@ local info = {
        s.field("sent_master_print_status_cmds", self.uint8, doc="Number of sent print_status commands"),
        s.field("sent_master_set_endpoint_delay_cmds", self.uint8, doc="Number of sent set_endpoint_delay commands"),
        s.field("sent_master_send_fl_command_cmds", self.uint8, doc="Number of sent send_fl_command commands"),
+       s.field("sent_master_measure_endpoint_rtt", self.uint8, doc="Number of sent measure_endpoint_rtt commands"),
+       s.field("sent_master_endpoint_scan", self.uint8, doc="Number of sent endpoint_scan commands"),
+       s.field("sent_master_start_periodic_fl_commands", self.uint8, doc="Number of start_periodic_fl_command commands"),
+       s.field("sent_master_stop_periodic_fl_commands", self.uint8, doc="Number of stop_periodic_fl_command commands")
+
    ], doc="TimingMasterController information")
 };
 

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -499,6 +499,10 @@ TimingHardwareManager::start_send_periodic_fl_cmd(const timingcmd::TimingHwCmd& 
   timingcmd::from_json(hw_cmd.payload, cmd_payload);
 
   auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
+  if (cmd_payload.fl_cmd_id == 0 || cmd_payload.fl_cmd_id ==1){
+    TLOG(0) << " Invalid command id (0 or 1) sent";
+    ers::warning(InvalidFLCommandID(ERS_HERE, hw_cmd.id, hw_cmd.device, cmd_payload.fl_cmd_id));
+  }
   design->enable_periodic_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.rate, cmd_payload.poisson);
 }
 

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -498,8 +498,8 @@ TimingHardwareManager::send_periodic_cmd(const timingcmd::TimingHwCmd& hw_cmd)
   timingcmd::TimingMasterSendFLCmdCmdPayload cmd_payload;
   timingcmd::from_json(hw_cmd.payload, cmd_payload);
 
-  // auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
-  // design->get_master_node_plain()->send_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.number_of_commands_to_send);
+  auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
+  design->get_master_node_plain()->send_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.number_of_commands_to_send);
 }
 
 

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -492,16 +492,27 @@ TimingHardwareManager::send_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd)
 
 
 void
-TimingHardwareManager::send_periodic_cmd(const timingcmd::TimingHwCmd& hw_cmd)
+TimingHardwareManager::start_send_periodic_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd)
 {
   TLOG_DEBUG(0) << get_name() << ": " << hw_cmd.device << " send periodic cmd";
-  timingcmd::TimingMasterSendFLCmdCmdPayload cmd_payload;
+  timingcmd::TimingMasterStartPeriodicFLCmd cmd_payload;
   timingcmd::from_json(hw_cmd.payload, cmd_payload);
 
   auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
-  design->get_master_node_plain()->send_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.number_of_commands_to_send);
+  design->get_master_node_plain()->enable_periodic_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.rate, cmd_payload.poisson, cmd_payload.clock_frequency_hz);
 }
 
+
+void
+TimingHardwareManager::stop_send_periodic_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd)
+{
+  TLOG_DEBUG(0) << get_name() << ": " << hw_cmd.device << " stop periodic cmd";
+  timingcmd::TimingMasterStopPeriodicFLCmd cmd_payload;
+  timingcmd::from_json(hw_cmd.payload, cmd_payload);
+
+  auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
+  design->get_master_node_plain()->disable_periodic_fl_cmd(cmd_payload.channel);
+}
 
 // endpoint commands
 void

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -490,6 +490,19 @@ TimingHardwareManager::send_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd)
   design->get_master_node_plain()->send_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.number_of_commands_to_send);
 }
 
+
+void
+TimingHardwareManager::send_periodic_cmd(const timingcmd::TimingHwCmd& hw_cmd)
+{
+  TLOG_DEBUG(0) << get_name() << ": " << hw_cmd.device << " send periodic cmd";
+  timingcmd::TimingMasterSendFLCmdCmdPayload cmd_payload;
+  timingcmd::from_json(hw_cmd.payload, cmd_payload);
+
+  // auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
+  // design->get_master_node_plain()->send_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.number_of_commands_to_send);
+}
+
+
 // endpoint commands
 void
 TimingHardwareManager::endpoint_enable(const timingcmd::TimingHwCmd& hw_cmd)

--- a/src/TimingHardwareManager.cpp
+++ b/src/TimingHardwareManager.cpp
@@ -499,7 +499,7 @@ TimingHardwareManager::start_send_periodic_fl_cmd(const timingcmd::TimingHwCmd& 
   timingcmd::from_json(hw_cmd.payload, cmd_payload);
 
   auto design = get_timing_device<const timing::MasterDesignInterface*>(hw_cmd.device);
-  design->get_master_node_plain()->enable_periodic_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.rate, cmd_payload.poisson, cmd_payload.clock_frequency_hz);
+  design->enable_periodic_fl_cmd(cmd_payload.fl_cmd_id, cmd_payload.channel, cmd_payload.rate, cmd_payload.poisson);
 }
 
 

--- a/src/TimingHardwareManager.hpp
+++ b/src/TimingHardwareManager.hpp
@@ -121,6 +121,7 @@ protected:
   void set_timestamp(const timingcmd::TimingHwCmd& hw_cmd);
   void set_endpoint_delay(const timingcmd::TimingHwCmd& hw_cmd);
   void send_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd);
+  void send_periodic_cmd(const timingcmd::TimingHwCmd& hw_cmd);
   void master_endpoint_scan(const timingcmd::TimingHwCmd& hw_cmd);
 
   // timing partition commands

--- a/src/TimingHardwareManager.hpp
+++ b/src/TimingHardwareManager.hpp
@@ -121,7 +121,8 @@ protected:
   void set_timestamp(const timingcmd::TimingHwCmd& hw_cmd);
   void set_endpoint_delay(const timingcmd::TimingHwCmd& hw_cmd);
   void send_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd);
-  void send_periodic_cmd(const timingcmd::TimingHwCmd& hw_cmd);
+  void start_send_periodic_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd);
+  void stop_send_periodic_fl_cmd(const timingcmd::TimingHwCmd& hw_cmd);
   void master_endpoint_scan(const timingcmd::TimingHwCmd& hw_cmd);
 
   // timing partition commands

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -47,6 +47,8 @@ TimingMasterController::TimingMasterController(const std::string& name)
   register_command("master_send_fl_command", &TimingMasterController::do_master_send_fl_command);
   register_command("master_measure_endpoint_rtt", &TimingMasterController::do_master_measure_endpoint_rtt);
   register_command("master_endpoint_scan", &TimingMasterController::do_master_endpoint_scan);
+  register_command("master_set_periodic_command_sends", &TimingMasterController::do_master_set_periodic_command_sends);
+  // master_set_periodic_command_send
 }
 
 void
@@ -184,6 +186,19 @@ TimingMasterController::do_master_endpoint_scan(const nlohmann::json& data)
   hw_cmd.payload = data;
   
   TLOG_DEBUG(2) << "endpoint scan data: " << data.dump();
+
+  send_hw_cmd(std::move(hw_cmd));
+  ++(m_sent_hw_command_counters.at(6).atomic);
+}
+
+void
+TimingMasterController::do_master_set_periodic_command_sends(const nlohmann::json& data)
+{
+  timingcmd::TimingHwCmd hw_cmd =
+  construct_master_hw_cmd( "do_master_set_periodic_command_sends");
+  hw_cmd.payload = data;
+  
+  TLOG_DEBUG(2) << "periodic commands: " << data.dump();
 
   send_hw_cmd(std::move(hw_cmd));
   ++(m_sent_hw_command_counters.at(6).atomic);

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -47,7 +47,8 @@ TimingMasterController::TimingMasterController(const std::string& name)
   register_command("master_send_fl_command", &TimingMasterController::do_master_send_fl_command);
   register_command("master_measure_endpoint_rtt", &TimingMasterController::do_master_measure_endpoint_rtt);
   register_command("master_endpoint_scan", &TimingMasterController::do_master_endpoint_scan);
-  register_command("master_set_periodic_command_sends", &TimingMasterController::do_master_set_periodic_command_sends);
+  register_command("master_start_periodic_fl_commands", &TimingMasterController::do_master_start_periodic_fl_commands);
+  register_command("master_stop_periodic_fl_commands", &TimingMasterController::do_master_stop_periodic_fl_commands);
 
 }
 
@@ -192,13 +193,26 @@ TimingMasterController::do_master_endpoint_scan(const nlohmann::json& data)
 }
 
 void
-TimingMasterController::do_master_set_periodic_command_sends(const nlohmann::json& data)
+TimingMasterController::do_master_start_periodic_fl_commands(const nlohmann::json& data)
 {
   timingcmd::TimingHwCmd hw_cmd =
-  construct_master_hw_cmd( "do_master_set_periodic_command_sends");
+  construct_master_hw_cmd( "master_start_periodic_fl_commands");
   hw_cmd.payload = data;
   
-  TLOG_DEBUG(2) << "periodic commands: " << data.dump();
+  TLOG_DEBUG(2) << "periodic commands start: " << data.dump();
+
+  send_hw_cmd(std::move(hw_cmd));
+  ++(m_sent_hw_command_counters.at(6).atomic);
+}
+
+void
+TimingMasterController::do_master_stop_periodic_fl_commands(const nlohmann::json& data)
+{
+  timingcmd::TimingHwCmd hw_cmd =
+  construct_master_hw_cmd( "master_stop_periodic_fl_commands");
+  hw_cmd.payload = data;
+  
+  TLOG_DEBUG(2) << "periodic commands stop: " << data.dump();
 
   send_hw_cmd(std::move(hw_cmd));
   ++(m_sent_hw_command_counters.at(6).atomic);

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -48,7 +48,7 @@ TimingMasterController::TimingMasterController(const std::string& name)
   register_command("master_measure_endpoint_rtt", &TimingMasterController::do_master_measure_endpoint_rtt);
   register_command("master_endpoint_scan", &TimingMasterController::do_master_endpoint_scan);
   register_command("master_set_periodic_command_sends", &TimingMasterController::do_master_set_periodic_command_sends);
-  // master_set_periodic_command_send
+
 }
 
 void

--- a/src/TimingMasterController.cpp
+++ b/src/TimingMasterController.cpp
@@ -30,7 +30,7 @@ namespace dunedaq {
 namespace timinglibs {
 
 TimingMasterController::TimingMasterController(const std::string& name)
-  : dunedaq::timinglibs::TimingController(name, 7) // 2nd arg: how many hw commands can this module send?
+  : dunedaq::timinglibs::TimingController(name, 9) // 2nd arg: how many hw commands can this module send?
   , m_endpoint_scan_period(0)
   , endpoint_scan_thread(std::bind(&TimingMasterController::endpoint_scan, this, std::placeholders::_1))
 {
@@ -202,7 +202,7 @@ TimingMasterController::do_master_start_periodic_fl_commands(const nlohmann::jso
   TLOG_DEBUG(2) << "periodic commands start: " << data.dump();
 
   send_hw_cmd(std::move(hw_cmd));
-  ++(m_sent_hw_command_counters.at(6).atomic);
+  ++(m_sent_hw_command_counters.at(7).atomic);
 }
 
 void
@@ -215,7 +215,7 @@ TimingMasterController::do_master_stop_periodic_fl_commands(const nlohmann::json
   TLOG_DEBUG(2) << "periodic commands stop: " << data.dump();
 
   send_hw_cmd(std::move(hw_cmd));
-  ++(m_sent_hw_command_counters.at(6).atomic);
+  ++(m_sent_hw_command_counters.at(8).atomic);
 }
 
 void
@@ -228,7 +228,11 @@ TimingMasterController::get_info(opmonlib::InfoCollector& ci, int /*level*/)
   module_info.sent_master_print_status_cmds = m_sent_hw_command_counters.at(2).atomic.load();
   module_info.sent_master_set_endpoint_delay_cmds = m_sent_hw_command_counters.at(3).atomic.load();
   module_info.sent_master_send_fl_command_cmds = m_sent_hw_command_counters.at(4).atomic.load();
-
+  module_info.sent_master_measure_endpoint_rtt = m_sent_hw_command_counters.at(5).atomic.load();
+  module_info.sent_master_endpoint_scan = m_sent_hw_command_counters.at(6).atomic.load();
+  module_info.sent_master_start_periodic_fl_commands = m_sent_hw_command_counters.at(7).atomic.load();
+  module_info.sent_master_stop_periodic_fl_commands = m_sent_hw_command_counters.at(8).atomic.load();
+  
   // for (uint i = 0; i < m_number_hw_commands; ++i) {
   //  module_info.sent_hw_command_counters.push_back(m_sent_hw_command_counters.at(i).atomic.load());
   //}

--- a/src/TimingMasterController.hpp
+++ b/src/TimingMasterController.hpp
@@ -79,6 +79,7 @@ protected:
   void do_master_send_fl_command(const nlohmann::json& data);
   void do_master_measure_endpoint_rtt(const nlohmann::json& data);
   void do_master_endpoint_scan(const nlohmann::json& data);
+  void do_master_set_periodic_command_sends(const nlohmann::json& data);
 
   // pass op mon info
   void get_info(opmonlib::InfoCollector& ci, int level) override;

--- a/src/TimingMasterController.hpp
+++ b/src/TimingMasterController.hpp
@@ -79,7 +79,8 @@ protected:
   void do_master_send_fl_command(const nlohmann::json& data);
   void do_master_measure_endpoint_rtt(const nlohmann::json& data);
   void do_master_endpoint_scan(const nlohmann::json& data);
-  void do_master_set_periodic_command_sends(const nlohmann::json& data);
+  void do_master_start_periodic_fl_commands(const nlohmann::json& data);
+  void do_master_stop_periodic_fl_commands(const nlohmann::json& data);
 
   // pass op mon info
   void get_info(opmonlib::InfoCollector& ci, int level) override;


### PR DESCRIPTION
This PR adds the ability to send periodic commands in the `nanotimingrc` session which would typically require using `dtsbutler` commands. 
To test that these changes don't break anything, I ran the `daqconf_timing_gen` command to generate a configuration folder containing: `boot.json`, `conf.json`, `data/`, among other files, as well as the new: `master_send_periodic_command_sends.json` which contains: 
```
{
    "apps": {
        "tmc": "data/tmc_master_send_periodic_command_sends"
    }
}
```
Then, I started a `nanotimingrc` session using the following cmd:  `nanotimingrc --partition-number 2 conf/ test-sess` where the `conf/` folder is the aforementioned generated folder. 