### PR TITLE
JCF: fix the fact that timinglibsConfig.cmake.in didn't conform to th…

### DIFF
--- a/cmake/timinglibsConfig.cmake.in
+++ b/cmake/timinglibsConfig.cmake.in
@@ -15,11 +15,15 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
+get_filename_component(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
+
 else()
 
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+
+set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 
 endif()
 


### PR DESCRIPTION
…e standard format described in daq-cmake/config/templates/Config.cmake.in, where @PROJECT_NAME@_DAQSHARE is defined