### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/timinglibs/TimingController.hpp
+++ b/include/timinglibs/TimingController.hpp
@@ -20,7 +20,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "iomanager/Sender.hpp"
 #include "iomanager/Receiver.hpp"
 #include "utilities/WorkerThread.hpp"

--- a/include/timinglibs/TimingController.hpp
+++ b/include/timinglibs/TimingController.hpp
@@ -20,7 +20,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "iomanager/Sender.hpp"
 #include "iomanager/Receiver.hpp"
 #include "utilities/WorkerThread.hpp"

--- a/include/timinglibs/TimingIssues.hpp
+++ b/include/timinglibs/TimingIssues.hpp
@@ -14,7 +14,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/include/timinglibs/TimingIssues.hpp
+++ b/include/timinglibs/TimingIssues.hpp
@@ -14,6 +14,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/plugins/TimingFanoutController.hpp
+++ b/plugins/TimingFanoutController.hpp
@@ -19,7 +19,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "utilities/WorkerThread.hpp"
 
 #include <memory>

--- a/plugins/TimingFanoutController.hpp
+++ b/plugins/TimingFanoutController.hpp
@@ -19,7 +19,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "utilities/WorkerThread.hpp"
 
 #include <memory>

--- a/src/InfoGatherer.hpp
+++ b/src/InfoGatherer.hpp
@@ -16,7 +16,7 @@
 #include "timing/timingfirmwareinfo/Structs.hpp"
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "iomanager/Sender.hpp"
 #include "iomanager/IOManager.hpp"

--- a/src/InfoGatherer.hpp
+++ b/src/InfoGatherer.hpp
@@ -16,7 +16,7 @@
 #include "timing/timingfirmwareinfo/Structs.hpp"
 
 #include "ers/Issue.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "iomanager/Sender.hpp"
 #include "iomanager/IOManager.hpp"

--- a/src/TimingMasterControllerBase.hpp
+++ b/src/TimingMasterControllerBase.hpp
@@ -20,7 +20,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "utilities/WorkerThread.hpp"
 
 #include <memory>

--- a/src/TimingMasterControllerBase.hpp
+++ b/src/TimingMasterControllerBase.hpp
@@ -20,7 +20,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "utilities/WorkerThread.hpp"
 
 #include <memory>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)