### PR TITLE
Johnfreeman/new daq cmake for v5.3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(oks REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
-add_dal_library(timing.schema.xml NAMESPACE dunedaq::timinglibs::dal DALDIR dal DEP_PKGS confmodel)
+daq_add_dal_library(timing.schema.xml NAMESPACE dunedaq::timinglibs::dal DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( timingcmd.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 msgp.hpp.j2 )
 
@@ -47,10 +47,10 @@ daq_add_library(TimingController.cpp TimingEndpointControllerBase.cpp TimingHard
 logging::logging confmodel::confmodel oks::oks ers::ers appfwk::appfwk)
 
 ##############################################################################
-daq_add_plugin(TimingHardwareManagerPDII duneDAQModule LINK_LIBRARIES timing::timing timinglibs dal_timinglibs uhal::uhal pugixml::pugixml)
-daq_add_plugin(TimingMasterControllerPDII duneDAQModule LINK_LIBRARIES timinglibs dal_timinglibs)
-daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs dal_timinglibs)
-daq_add_plugin(TimingFanoutController duneDAQModule LINK_LIBRARIES timinglibs dal_timinglibs)
+daq_add_plugin(TimingHardwareManagerPDII duneDAQModule LINK_LIBRARIES timing::timing timinglibs timinglibs_dal uhal::uhal pugixml::pugixml)
+daq_add_plugin(TimingMasterControllerPDII duneDAQModule LINK_LIBRARIES timinglibs timinglibs_dal)
+daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs timinglibs_dal)
+daq_add_plugin(TimingFanoutController duneDAQModule LINK_LIBRARIES timinglibs timinglibs_dal)
 
 ##############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(oks REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
-daq_oks_codegen(timing.schema.xml NAMESPACE dunedaq::timinglibs::dal DALDIR dal DEP_PKGS confmodel)
+add_dal_library(timing.schema.xml NAMESPACE dunedaq::timinglibs::dal DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( timingcmd.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 msgp.hpp.j2 )
 
@@ -47,10 +47,10 @@ daq_add_library(TimingController.cpp TimingEndpointControllerBase.cpp TimingHard
 logging::logging confmodel::confmodel oks::oks ers::ers appfwk::appfwk)
 
 ##############################################################################
-daq_add_plugin(TimingHardwareManagerPDII duneDAQModule LINK_LIBRARIES timing::timing timinglibs uhal::uhal pugixml::pugixml)
-daq_add_plugin(TimingMasterControllerPDII duneDAQModule LINK_LIBRARIES timinglibs)
-daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs)
-daq_add_plugin(TimingFanoutController duneDAQModule LINK_LIBRARIES timinglibs)
+daq_add_plugin(TimingHardwareManagerPDII duneDAQModule LINK_LIBRARIES timing::timing timinglibs dal_timinglibs uhal::uhal pugixml::pugixml)
+daq_add_plugin(TimingMasterControllerPDII duneDAQModule LINK_LIBRARIES timinglibs dal_timinglibs)
+daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs dal_timinglibs)
+daq_add_plugin(TimingFanoutController duneDAQModule LINK_LIBRARIES timinglibs dal_timinglibs)
 
 ##############################################################################
 

--- a/cmake/timinglibsConfig.cmake.in
+++ b/cmake/timinglibsConfig.cmake.in
@@ -28,6 +28,9 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
+add_library(@PROJECT_NAME@::dal_@PROJECT_NAME@ ALIAS dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::dal                ALIAS dal_@PROJECT_NAME@)
+
 get_filename_component(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
 else()
@@ -35,6 +38,7 @@ else()
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
+add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::dal_@PROJECT_NAME@)
 
 set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 

--- a/cmake/timinglibsConfig.cmake.in
+++ b/cmake/timinglibsConfig.cmake.in
@@ -28,8 +28,8 @@ if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as repo (found in ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)")
 add_library(@PROJECT_NAME@::@PROJECT_NAME@ ALIAS @PROJECT_NAME@)
 
-add_library(@PROJECT_NAME@::dal_@PROJECT_NAME@ ALIAS dal_@PROJECT_NAME@)
-add_library(@PROJECT_NAME@::dal                ALIAS dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::@PROJECT_NAME@_dal ALIAS @PROJECT_NAME@_dal)
+add_library(@PROJECT_NAME@::dal                ALIAS @PROJECT_NAME@_dal)
 
 get_filename_component(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
@@ -38,7 +38,7 @@ else()
 message(STATUS "Project \"@PROJECT_NAME@\" will be treated as installed package (found in ${CMAKE_CURRENT_LIST_DIR})")
 set_and_check(targets_file ${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 include(${targets_file})
-add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::dal_@PROJECT_NAME@)
+add_library(@PROJECT_NAME@::dal ALIAS @PROJECT_NAME@::@PROJECT_NAME@_dal)
 
 set(@PROJECT_NAME@_DAQSHARE "${CMAKE_CURRENT_LIST_DIR}/../../../share")
 


### PR DESCRIPTION
The following PR enables this package to build on its patch branch against `daq-cmake` `v3.1.0`, which contains changes described in DUNE-DAQ/daq-cmake#155. 

This is only to be merged by Software Coordination. 