### PR TITLE
ReusableThread include removed from iomanager, include directly

### DIFF
--- a/src/TimingHardwareManagerBase.hpp
+++ b/src/TimingHardwareManagerBase.hpp
@@ -34,7 +34,7 @@
 #include "timing/TopDesignInterface.hpp"
 
 #include "uhal/ConnectionManager.hpp"
-#include "utilities/WorkerThread.hpp"
+#include "utilities/ReusableThread.hpp"
 
 #include <map>
 #include <memory>


### PR DESCRIPTION
https://github.com/DUNE-DAQ/iomanager/pull/121