### PR TITLE
JCF: Issue #155: remove need to add a link to timinglibs::dal wheneve…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@ find_package(opmonlib REQUIRED)
 find_package(uhal REQUIRED)
 find_package(pugixml REQUIRED)
 find_package(iomanager REQUIRED)
-find_package(okssystem REQUIRED)
-find_package(oks REQUIRED)
-find_package(oksdalgen REQUIRED)
 find_package(conffwk REQUIRED)
 
 daq_add_dal_library(timing.schema.xml NAMESPACE dunedaq::timinglibs::dal DALDIR dal DEP_PKGS confmodel)
@@ -40,19 +37,17 @@ set(TIMINGLIBS_DEPENDENCIES
   timing::timing
   uhal::uhal
   pugixml::pugixml
+  confmodel::confmodel
 )
 
 ##############################################################################
-daq_add_library(TimingController.cpp TimingEndpointControllerBase.cpp TimingHardwareInterface.cpp TimingHardwareManagerBase.cpp TimingMasterControllerBase.cpp LINK_LIBRARIES ${TIMINGLIBS_DEPENDENCIES} conffwk::conffwk okssystem::okssystem
-logging::logging confmodel::confmodel oks::oks ers::ers appfwk::appfwk)
+daq_add_library(TimingController.cpp TimingEndpointControllerBase.cpp TimingHardwareInterface.cpp TimingHardwareManagerBase.cpp TimingMasterControllerBase.cpp LINK_LIBRARIES ${TIMINGLIBS_DEPENDENCIES} timinglibs_dal)
 
 ##############################################################################
-daq_add_plugin(TimingHardwareManagerPDII duneDAQModule LINK_LIBRARIES timing::timing timinglibs timinglibs_dal uhal::uhal pugixml::pugixml)
-daq_add_plugin(TimingMasterControllerPDII duneDAQModule LINK_LIBRARIES timinglibs timinglibs_dal)
-daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs timinglibs_dal)
-daq_add_plugin(TimingFanoutController duneDAQModule LINK_LIBRARIES timinglibs timinglibs_dal)
-
-##############################################################################
+daq_add_plugin(TimingHardwareManagerPDII duneDAQModule LINK_LIBRARIES timinglibs)
+daq_add_plugin(TimingMasterControllerPDII duneDAQModule LINK_LIBRARIES timinglibs)
+daq_add_plugin(TimingEndpointController duneDAQModule LINK_LIBRARIES timinglibs)
+daq_add_plugin(TimingFanoutController duneDAQModule LINK_LIBRARIES timinglibs)
 
 ##############################################################################
 daq_install()

--- a/cmake/timinglibsConfig.cmake.in
+++ b/cmake/timinglibsConfig.cmake.in
@@ -15,9 +15,6 @@ find_dependency(opmonlib)
 find_dependency(uhal)
 find_dependency(pugixml)
 find_dependency(iomanager)
-find_dependency(okssystem)
-find_dependency(oks)
-find_dependency(oksdalgen)
 find_dependency(conffwk)
 
 # Figure out whether or not this dependency is an installed package or


### PR DESCRIPTION
…r timinglibs::timinglibs is linked against

# Description

The problem is described in Issue #155. Two things I'll point out:
* Yesterday's `TLFD_DEV_260302_A9` test build uses this feature branch and (as its existence suggests!) built fine
* I also removed some explicit dependencies on core OKS packages which aren't directly used in this package and removed some redundant package linkings.

_Please also include instructions for how a reviewer can test your changes._
Follow "Steps to reproduce" in https://github.com/DUNE-DAQ/timinglibs/issues/155. Then switch to this feature branch, and try it again. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist



- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [X] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_
There are no unit tests or integration tests in `timinglibs`
The global integration tests [ran fine](https://github.com/DUNE-DAQ/daq-release/actions/runs/22597724957) using the test build 

## Further checks

The below is N/A for a linking change. 

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

